### PR TITLE
Wire speculative cache, expose stats, and add lock retry

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -19,7 +19,11 @@ pub async fn run(config: ServerConfig) -> anyhow::Result<()> {
 
     // Retry opening the database with a timeout to handle lock contention
     // (e.g., another instance is shutting down)
-    let db = open_with_retry(Path::new(&config.data_dir), 5, std::time::Duration::from_secs(1))?;
+    let db = open_with_retry(
+        Path::new(&config.data_dir),
+        5,
+        std::time::Duration::from_secs(1),
+    )?;
     let server = MenteDbServer::new(db, config);
 
     // Keep a reference to the DB for graceful shutdown

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1708,9 +1708,9 @@ impl MenteDbServer {
 
         // Try the speculative cache before doing the full O(n) scan
         let mut cache = self.speculative_cache.lock().await;
-        let cache_result = cache.try_hit(&req.user_message).map(|entry| {
-            (entry.memory_ids.clone(), entry.topic.clone())
-        });
+        let cache_result = cache
+            .try_hit(&req.user_message)
+            .map(|entry| (entry.memory_ids.clone(), entry.topic.clone()));
         drop(cache);
         let cache_hit = cache_result.is_some();
 
@@ -1719,7 +1719,8 @@ impl MenteDbServer {
 
         // On cache hit, use cached memory IDs for a targeted lookup instead of
         // scoring every memory. Fall through to full scan if cached IDs are stale.
-        let (context_items, _current_ids) = if let Some((ref cached_ids, ref _topic)) = cache_result {
+        let (context_items, _current_ids) = if let Some((ref cached_ids, ref _topic)) = cache_result
+        {
             let cached_id_set: std::collections::HashSet<MemoryId> =
                 cached_ids.iter().cloned().collect();
             let matched: Vec<&ScoredMemory> = all
@@ -1731,8 +1732,7 @@ impl MenteDbServer {
                 // Enough cached IDs still exist, use them
                 let ids: Vec<MemoryId> = matched.iter().map(|sm| sm.memory.id).collect();
                 let mut delta_tracker = self.delta_tracker.lock().await;
-                let delta =
-                    delta_tracker.compute_delta(&ids, &delta_tracker.last_served.clone());
+                let delta = delta_tracker.compute_delta(&ids, &delta_tracker.last_served.clone());
                 delta_tracker.update(&ids);
                 drop(delta_tracker);
 
@@ -2037,9 +2037,7 @@ impl MenteDbServer {
                     })
                     .filter(|(sim, _)| *sim > 0.3)
                     .collect();
-                scored.sort_by(|a, b| {
-                    b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
-                });
+                scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
                 let top: Vec<&ScoredMemory> = scored.iter().take(5).map(|(_, sm)| *sm).collect();
                 if top.is_empty() {
                     return None;


### PR DESCRIPTION
Closes #18, closes #19, closes #20

**#18 — Wire speculative cache into process_turn**
- Added SpeculativeCache (64 entries, 0.5 threshold) to MenteDbServer
- On each process_turn, tries cache.try_hit() before the full O(n) cosine scan
- If cached memory IDs are still valid (>50% exist), skips the scan entirely
- After trajectory predictions, calls pre_assemble() to build context for likely next queries
- Returns cache_hit boolean in the response so agents know when context was served from cache

**#19 — Expose cache stats in cognitive_state**
- get_cognitive_state now includes speculative_cache section with hits, misses, evictions, cache_size, and computed hit_rate

**#20 — Workspace scoped database locking**
- Database open now retries up to 5 times (1s apart) on lock contention
- Handles the common case where a previous MCP instance is still shutting down
- Clear log messages at info level instead of crashing immediately
- --data-dir already supports per workspace paths (documented in README)