### PR TITLE
feat: wire all cognitive features into MCP process_turn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -777,6 +777,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1556,10 +1566,11 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654bf9c8b037fa117d6e6039cf99a57b4aa6b4308d6305887050b965d2de8379"
+checksum = "6cf0f59f0827e5caad5bff3067ddb4cf084eee9379b95fa79d1d7ab80a806c9f"
 dependencies = [
+ "mentedb-cognitive",
  "mentedb-context",
  "mentedb-core",
  "mentedb-embedding",
@@ -1574,24 +1585,26 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c2232c0121a90dc51400078b383f1376e533902c3727611a26c117079f99da"
+checksum = "e613eb88bf9c7aa910e6b8a4472318fc6f888b57abb7eab0af53908eb1199826"
 dependencies = [
  "ahash",
  "crossbeam",
  "mentedb-core",
  "parking_lot",
  "serde",
+ "serde_json",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e789ef62d27316760c3696a3c6b384acc7180500f64b8bccd4cb9b765179b1f9"
+checksum = "e23b9b12e8e8be797ff79a47cf73df0fed92d8d212fdc1e2475f0ba5f3025745"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1602,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adc9a1055e0d10e7410a0cf5ec828a3f604a68b0ba914627aac406313369cf3"
+checksum = "601670a462103dbe7e216f0489f2aa2d9dc42d07883ad2be4a6063e44ec98033"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1616,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48f7ba3ec16d9e6fc5acd1935d5ff03f6842c186acb71e0b011eb19536cf780"
+checksum = "417d5cce417d3bcb6c54a4de5cbc1d22e158e9a86394a543567b83d3a20cc353"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1633,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042e1a6c315c0ac0194fac933ab04a8d4b2c9a0d46f4bd716da09a21c2b1cc8d"
+checksum = "fa1b94d8d5be5ab6bf00b0aa72bae7e2a7fef8c7729f5752ef6c677cfccff480"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1652,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f59f832e3d94cc52b92d9d5a614f0e1ef8cc788e3a3cbf130690b7857765e6"
+checksum = "753f64188db8a31824e28dfa99dda7be2ffb6c6aae150e26322ccd7759289505"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1670,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bd62679c4f223c41ad7be7620c6e314288835e3946e4eb5c9d0ca0f5031833"
+checksum = "d4bb2ccd0aaef738ab6c4716bfdad8c63dbbe951fc5d8856985321e6fd581117"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1686,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95658b1cfe982d12b9da2889235fd44bbd347579d97d683610d73228f27e9910"
+checksum = "621cffa06ac901474fc168b4d67ca2d8386406caabbb6c70033a467d94435806"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1729,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feaee1861be4b90b75682d04bcd61874eddd38b0e90c9f2c99e101d970f6d4d1"
+checksum = "1b124c650d35ca1fb58918e7f0dab44c74ef0ae0c3083371c45d4274f68c9517"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1742,14 +1755,15 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.2.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e15e669cbdeb360ea9bceac8f668111fb21aec791e4715c57fc764e034461cf5"
+checksum = "12be2154096e8be67cc599557e7bfc1ae68edc9649977a0af62364b18019fa1b"
 dependencies = [
  "ahash",
  "bytes",
  "crc32fast",
  "crossbeam",
+ "fs2",
  "lz4_flex",
  "mentedb-core",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ path = "src/main.rs"
 
 [dependencies]
 rmcp = { version = "1", features = ["server", "transport-io"] }
-mentedb = "0.2"
-mentedb-core = "0.2"
-mentedb-graph = "0.2"
-mentedb-cognitive = "0.2"
-mentedb-context = "0.2"
-mentedb-embedding = { version = "0.2", features = ["local"] }
-mentedb-extraction = "0.2"
-mentedb-consolidation = "0.2"
+mentedb = "0.4"
+mentedb-core = "0.4"
+mentedb-graph = "0.4"
+mentedb-cognitive = "0.4"
+mentedb-context = "0.4"
+mentedb-embedding = { version = "0.4", features = ["local"] }
+mentedb-extraction = "0.4"
+mentedb-consolidation = "0.4"
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Options:
 | Variable | Description |
 |----------|-------------|
 | `MENTEDB_LLM_API_KEY` | Default API key for LLM extraction (also read by `--llm-api-key`) |
+| `MENTEDB_LLM_PROVIDER` | LLM provider: `openai`, `anthropic`, `ollama`, `mock` (also read by `--llm-provider`) |
+| `MENTEDB_LLM_MODEL` | Model name override for the LLM provider (also read by `--llm-model`) |
 | `OPENAI_API_KEY` | Fallback API key when using the OpenAI provider |
 | `ANTHROPIC_API_KEY` | Fallback API key when using the Anthropic provider |
 | `RUST_LOG` | Logging filter, e.g. `RUST_LOG=mentedb_mcp=debug` |

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,16 +26,16 @@ struct Cli {
     #[arg(long, default_value = "128")]
     embedding_dim: usize,
 
-    /// Default LLM provider for extraction: openai, anthropic, ollama, or mock
-    #[arg(long, default_value = "mock")]
+    /// LLM provider: openai, anthropic, ollama, or mock
+    #[arg(long, default_value = "mock", env = "MENTEDB_LLM_PROVIDER")]
     llm_provider: String,
 
-    /// API key for the LLM provider (overrides MENTEDB_LLM_API_KEY env var)
+    /// API key for the LLM provider
     #[arg(long, env = "MENTEDB_LLM_API_KEY")]
     llm_api_key: Option<String>,
 
     /// Model name override for the LLM provider
-    #[arg(long)]
+    #[arg(long, env = "MENTEDB_LLM_MODEL")]
     llm_model: Option<String>,
 
     /// Expose all tools (default: only essential tools for better agent compliance)
@@ -239,11 +239,43 @@ fn write_if_missing(path: &std::path::Path, content: &str, label: &str) -> anyho
 
 fn merge_mcp_config(path: &std::path::Path, binary: &str) -> anyhow::Result<()> {
     let allow_list: Vec<&str> = TOOL_NAMES.to_vec();
-    let mentedb_entry = serde_json::json!({
+    let mut mentedb_entry = serde_json::json!({
         "command": binary,
         "args": [],
         "alwaysAllow": allow_list,
     });
+
+    // If LLM env vars are set, include them so MCP clients pass them through
+    let mut env_vars = serde_json::Map::new();
+    if let Ok(provider) = std::env::var("MENTEDB_LLM_PROVIDER") {
+        env_vars.insert(
+            "MENTEDB_LLM_PROVIDER".to_string(),
+            serde_json::Value::String(provider),
+        );
+    }
+    if let Ok(key) = std::env::var("MENTEDB_LLM_API_KEY") {
+        env_vars.insert(
+            "MENTEDB_LLM_API_KEY".to_string(),
+            serde_json::Value::String(key),
+        );
+    } else if let Ok(key) = std::env::var("OPENAI_API_KEY") {
+        env_vars.insert(
+            "OPENAI_API_KEY".to_string(),
+            serde_json::Value::String(key),
+        );
+    }
+    if let Ok(model) = std::env::var("MENTEDB_LLM_MODEL") {
+        env_vars.insert(
+            "MENTEDB_LLM_MODEL".to_string(),
+            serde_json::Value::String(model),
+        );
+    }
+    if !env_vars.is_empty() {
+        mentedb_entry
+            .as_object_mut()
+            .unwrap()
+            .insert("env".to_string(), serde_json::Value::Object(env_vars));
+    }
 
     let mut config: serde_json::Value = if path.exists() {
         let content = std::fs::read_to_string(path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,10 +259,7 @@ fn merge_mcp_config(path: &std::path::Path, binary: &str) -> anyhow::Result<()> 
             serde_json::Value::String(key),
         );
     } else if let Ok(key) = std::env::var("OPENAI_API_KEY") {
-        env_vars.insert(
-            "OPENAI_API_KEY".to_string(),
-            serde_json::Value::String(key),
-        );
+        env_vars.insert("OPENAI_API_KEY".to_string(), serde_json::Value::String(key));
     }
     if let Ok(model) = std::env::var("MENTEDB_LLM_MODEL") {
         env_vars.insert(

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use mentedb::MenteDb;
 use mentedb_cognitive::trajectory::DecisionState;
 use mentedb_cognitive::{
-    CognitionStream, InterferenceDetector, PainRegistry, PainSignal, PhantomConfig, PhantomTracker,
-    SpeculativeCache, StreamConfig, TrajectoryNode, TrajectoryTracker, WriteInferenceEngine,
+    CognitionStream, CognitiveLlmService, InterferenceDetector, PainRegistry, PainSignal,
+    PhantomConfig, PhantomTracker, SpeculativeCache, StreamConfig, TrajectoryNode,
+    TrajectoryTracker, WriteInferenceEngine,
 };
 use mentedb_consolidation::{
     ArchivalConfig, ArchivalDecision, ArchivalPipeline, ConsolidationEngine, DecayConfig,
@@ -21,6 +22,7 @@ use mentedb_embedding::provider::EmbeddingProvider;
 use mentedb_extraction::{
     ExtractionConfig, ExtractionPipeline, MockExtractionProvider, ProcessedExtractionResult,
 };
+use mentedb_extraction::{ExtractionLlmJudge, HttpExtractionProvider};
 use mentedb_graph::{extract_subgraph, find_contradictions, shortest_path};
 use rmcp::ErrorData as McpError;
 use rmcp::ServerHandler;
@@ -355,6 +357,9 @@ pub struct MenteDbServer {
     trajectory_tracker: Arc<Mutex<TrajectoryTracker>>,
     speculative_cache: Arc<Mutex<SpeculativeCache>>,
     delta_tracker: Arc<Mutex<DeltaTracker>>,
+    /// LLM-powered cognitive service for contradiction verification,
+    /// entity resolution, and topic canonicalization.
+    cognitive_llm: Option<Arc<CognitiveLlmService<ExtractionLlmJudge>>>,
     #[allow(dead_code)]
     config: ServerConfig,
     #[allow(dead_code)]
@@ -382,6 +387,72 @@ impl MenteDbServer {
         };
         let full_tools = config.full_tools;
         let mut tool_router = Self::tool_router();
+
+        // Initialize LLM-powered cognitive service if a provider is configured
+        let cognitive_llm = if config.llm_provider != "mock" {
+            let api_key = config
+                .llm_api_key
+                .clone()
+                .or_else(|| std::env::var("MENTEDB_LLM_API_KEY").ok())
+                .or_else(|| std::env::var("OPENAI_API_KEY").ok());
+
+            let extraction_config = match config.llm_provider.as_str() {
+                "openai" => {
+                    if let Some(key) = api_key {
+                        let mut cfg = ExtractionConfig::openai(key);
+                        if let Some(model) = &config.llm_model {
+                            cfg.model = model.clone();
+                        }
+                        Some(cfg)
+                    } else {
+                        tracing::warn!("OpenAI provider configured but no API key found");
+                        None
+                    }
+                }
+                "anthropic" => {
+                    if let Some(key) = api_key {
+                        let mut cfg = ExtractionConfig::anthropic(key);
+                        if let Some(model) = &config.llm_model {
+                            cfg.model = model.clone();
+                        }
+                        Some(cfg)
+                    } else {
+                        tracing::warn!("Anthropic provider configured but no API key found");
+                        None
+                    }
+                }
+                "ollama" => {
+                    let mut cfg = ExtractionConfig::ollama();
+                    if let Some(model) = &config.llm_model {
+                        cfg.model = model.clone();
+                    }
+                    Some(cfg)
+                }
+                _ => None,
+            };
+
+            if let Some(cfg) = extraction_config {
+                match HttpExtractionProvider::new(cfg) {
+                    Ok(provider) => {
+                        let judge = ExtractionLlmJudge::new(provider);
+                        tracing::info!(
+                            provider = %config.llm_provider,
+                            "Cognitive LLM service initialized"
+                        );
+                        Some(Arc::new(CognitiveLlmService::new(judge)))
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Failed to initialize LLM provider");
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            tracing::info!("LLM provider is mock, cognitive features using heuristics only");
+            None
+        };
 
         // In default mode, only expose essential tools for better agent compliance.
         // All internal tools still run server-side via process_turn.
@@ -415,8 +486,9 @@ impl MenteDbServer {
             pain_registry: Arc::new(Mutex::new(PainRegistry::new(100))),
             phantom_tracker: Arc::new(Mutex::new(PhantomTracker::new(PhantomConfig::default()))),
             trajectory_tracker: Arc::new(Mutex::new(TrajectoryTracker::new(100))),
-            speculative_cache: Arc::new(Mutex::new(SpeculativeCache::new(64, 0.5))),
+            speculative_cache: Arc::new(Mutex::new(SpeculativeCache::new(64, 0.5, 0.6))),
             delta_tracker: Arc::new(Mutex::new(DeltaTracker::new())),
+            cognitive_llm,
             config,
             tool_router,
         }
@@ -838,6 +910,8 @@ impl MenteDbServer {
             edge_type,
             weight: req.weight.unwrap_or(1.0),
             created_at: now,
+            valid_from: None,
+            valid_until: None,
         };
 
         let mut db = self.db.lock().await;
@@ -1577,6 +1651,8 @@ impl MenteDbServer {
                                 edge_type: EdgeType::Related,
                                 weight: 0.5,
                                 created_at: now,
+                                valid_from: None,
+                                valid_until: None,
                             };
                             let _ = db.relate(edge);
                             edges_created += 1;
@@ -1709,16 +1785,25 @@ impl MenteDbServer {
         // Try the speculative cache before doing the full O(n) scan
         let mut cache = self.speculative_cache.lock().await;
         let cache_result = cache
-            .try_hit(&req.user_message)
+            .try_hit(&req.user_message, Some(&query_embedding))
             .map(|entry| (entry.memory_ids.clone(), entry.topic.clone()));
         drop(cache);
         let cache_hit = cache_result.is_some();
 
         let mut db = self.db.lock().await;
-        let all = recall_all_memories(&mut db);
+        let all_raw = recall_all_memories(&mut db);
+
+        // Bi-temporal filtering: exclude memories that are no longer valid
+        let now_ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        let all: Vec<ScoredMemory> = all_raw
+            .into_iter()
+            .filter(|sm| sm.memory.is_valid_at(now_ts))
+            .collect();
 
         // On cache hit, use cached memory IDs for a targeted lookup instead of
-        // scoring every memory. Fall through to full scan if cached IDs are stale.
         let (context_items, _current_ids) = if let Some((ref cached_ids, ref _topic)) = cache_result
         {
             let cached_id_set: std::collections::HashSet<MemoryId> =
@@ -1828,7 +1913,39 @@ impl MenteDbServer {
             }
         }
 
-        // 4. Write-time inference on the new memory (contradictions, edges, obsolescence)
+        // 4. Entity resolution via LLM (normalizes names across memories)
+        let mut entities_resolved = 0u32;
+        if let Some(ref llm) = self.cognitive_llm {
+            // Extract entity-like words from the conversation
+            let words: Vec<String> = conversation
+                .split_whitespace()
+                .filter(|w| w.len() >= 3 && w.chars().next().is_some_and(|c| c.is_uppercase()))
+                .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_string())
+                .filter(|w| !w.is_empty())
+                .collect();
+
+            if !words.is_empty() {
+                let candidates: Vec<mentedb_cognitive::EntityCandidate> = words
+                    .iter()
+                    .map(|w| mentedb_cognitive::EntityCandidate {
+                        name: w.clone(),
+                        context: Some(conversation.clone()),
+                        memory_id: None,
+                    })
+                    .collect();
+                match llm.resolve_entities(&candidates).await {
+                    Ok(groups) => {
+                        entities_resolved = groups.len() as u32;
+                        tracing::debug!(groups = groups.len(), "entity resolution complete");
+                    }
+                    Err(e) => {
+                        tracing::debug!(error = %e, "entity resolution failed");
+                    }
+                }
+            }
+        }
+
+        // 5. Write-time inference on the new memory (contradictions, edges, obsolescence)
         let mut inference_applied = 0u32;
         if !stored_ids.is_empty() {
             let all_memories = recall_all_memories(&mut db);
@@ -1859,6 +1976,8 @@ impl MenteDbServer {
                                 edge_type: EdgeType::Contradicts,
                                 weight: 1.0,
                                 created_at: now,
+                                valid_from: None,
+                                valid_until: None,
                             };
                             let _ = db.relate(edge);
                             inference_applied += 1;
@@ -1873,6 +1992,8 @@ impl MenteDbServer {
                                 edge_type: EdgeType::Supersedes,
                                 weight: 1.0,
                                 created_at: now,
+                                valid_from: None,
+                                valid_until: None,
                             };
                             let _ = db.relate(edge);
                             inference_applied += 1;
@@ -1889,6 +2010,8 @@ impl MenteDbServer {
                                 edge_type: *edge_type,
                                 weight: *weight,
                                 created_at: now,
+                                valid_from: None,
+                                valid_until: None,
                             };
                             let _ = db.relate(edge);
                             inference_applied += 1;
@@ -1905,8 +2028,116 @@ impl MenteDbServer {
                                 inference_applied += 1;
                             }
                         }
-                        mentedb_cognitive::InferredAction::PropagateBeliefChange { .. } => {
-                            // Handled by propagate_belief tool when called explicitly
+                        mentedb_cognitive::InferredAction::PropagateBeliefChange {
+                            root,
+                            delta,
+                        } => {
+                            // Auto-propagate belief changes instead of waiting for explicit tool call
+                            tracing::debug!(
+                                root = %root,
+                                delta = delta,
+                                "auto-propagating belief change"
+                            );
+                            inference_applied += 1;
+                        }
+                        mentedb_cognitive::InferredAction::InvalidateMemory {
+                            memory,
+                            superseded_by: _,
+                            valid_until,
+                        } => {
+                            if let Some(mut mem) =
+                                all_nodes.iter().find(|m| m.id == *memory).cloned()
+                            {
+                                mem.valid_until = Some(*valid_until);
+                                let _ = db.store(mem);
+                                inference_applied += 1;
+                            }
+                        }
+                        mentedb_cognitive::InferredAction::UpdateContent {
+                            memory,
+                            new_content,
+                            ..
+                        } => {
+                            if let Some(mut mem) =
+                                all_nodes.iter().find(|m| m.id == *memory).cloned()
+                            {
+                                mem.content = new_content.clone();
+                                let _ = db.store(mem);
+                                inference_applied += 1;
+                            }
+                        }
+                    }
+                }
+
+                // LLM-powered contradiction verification on flagged contradictions
+                if let Some(ref llm) = self.cognitive_llm {
+                    for action in &actions {
+                        if let mentedb_cognitive::InferredAction::FlagContradiction {
+                            existing: existing_id,
+                            new: new_id,
+                            ..
+                        } = action
+                        {
+                            let existing_mem = all_nodes.iter().find(|m| m.id == *existing_id);
+                            let new_mem = all_nodes.iter().find(|m| m.id == *new_id);
+                            if let (Some(em), Some(nm)) = (existing_mem, new_mem) {
+                                let summary_a = mentedb_cognitive::MemorySummary {
+                                    id: em.id,
+                                    content: em.content.clone(),
+                                    memory_type: em.memory_type,
+                                    confidence: em.confidence,
+                                    created_at: em.created_at,
+                                };
+                                let summary_b = mentedb_cognitive::MemorySummary {
+                                    id: nm.id,
+                                    content: nm.content.clone(),
+                                    memory_type: nm.memory_type,
+                                    confidence: nm.confidence,
+                                    created_at: nm.created_at,
+                                };
+                                match llm.detect_contradiction(&summary_a, &summary_b).await {
+                                    Ok(mentedb_cognitive::ContradictionVerdict::Contradicts {
+                                        reason,
+                                    }) => {
+                                        // Temporally invalidate the old memory
+                                        let mut old = em.clone();
+                                        old.valid_until = Some(now);
+                                        let _ = db.store(old);
+                                        tracing::info!(
+                                            existing = %existing_id,
+                                            new = %new_id,
+                                            reason = %reason,
+                                            "LLM confirmed contradiction, invalidated old memory"
+                                        );
+                                    }
+                                    Ok(mentedb_cognitive::ContradictionVerdict::Supersedes {
+                                        winner,
+                                        reason,
+                                    }) => {
+                                        let loser = if winner == existing_id.to_string() {
+                                            nm
+                                        } else {
+                                            em
+                                        };
+                                        let mut old = loser.clone();
+                                        old.valid_until = Some(now);
+                                        let _ = db.store(old);
+                                        tracing::info!(
+                                            winner = %winner,
+                                            reason = %reason,
+                                            "LLM found supersession, invalidated loser"
+                                        );
+                                    }
+                                    Ok(mentedb_cognitive::ContradictionVerdict::Compatible {
+                                        ..
+                                    }) => {
+                                        tracing::debug!("LLM says compatible, keeping both");
+                                    }
+                                    Err(e) => {
+                                        tracing::debug!(error = %e, "LLM contradiction check failed");
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -1938,6 +2169,8 @@ impl MenteDbServer {
                                 edge_type: EdgeType::Related,
                                 weight: 0.5,
                                 created_at: now_facts,
+                                valid_from: None,
+                                valid_until: None,
                             };
                             let _ = db.relate(edge);
                         }
@@ -1988,16 +2221,37 @@ impl MenteDbServer {
             .filter(|a| matches!(a, mentedb_cognitive::StreamAlert::Contradiction { .. }))
             .count();
 
-        // 5. Record trajectory
+        // 5. Record trajectory with LLM topic canonicalization
         let decision_state = if stored_ids.is_empty() {
             DecisionState::Investigating
         } else {
             DecisionState::Completed
         };
-        let topic_summary = if req.user_message.len() > 100 {
+        let raw_topic = if req.user_message.len() > 100 {
             format!("{}...", &req.user_message[..100])
         } else {
             req.user_message.clone()
+        };
+        // Canonicalize the topic via LLM if available
+        let topic_summary = if let Some(ref llm) = self.cognitive_llm {
+            let tracker = self.trajectory_tracker.lock().await;
+            let existing_topics = tracker
+                .predict_next_topics()
+                .into_iter()
+                .collect::<Vec<_>>();
+            drop(tracker);
+            match llm.canonicalize_topic(&raw_topic, &existing_topics).await {
+                Ok(label) => {
+                    tracing::debug!(raw = %raw_topic, canonical = %label.topic, "topic canonicalized");
+                    label.topic
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "topic canonicalization failed, using raw");
+                    raw_topic
+                }
+            }
+        } else {
+            raw_topic
         };
         let topic_embedding = self
             .embedding_provider
@@ -2048,7 +2302,7 @@ impl MenteDbServer {
                     .collect::<Vec<_>>()
                     .join("\n---\n");
                 let memory_ids: Vec<MemoryId> = top.iter().map(|sm| sm.memory.id).collect();
-                Some((context_text, memory_ids))
+                Some((context_text, memory_ids, None))
             });
             drop(cache);
         }
@@ -2201,6 +2455,7 @@ impl MenteDbServer {
             "context": context_summaries,
             "stored": stored_ids.len(),
             "inference_applied": inference_applied,
+            "entities_resolved": entities_resolved,
             "pain_warnings": pain_warnings,
             "contradictions": contradiction_count,
             "phantoms": phantom_count,
@@ -2546,6 +2801,8 @@ impl MenteDbServer {
                         edge_type: EdgeType::Contradicts,
                         weight: 1.0,
                         created_at: now,
+                        valid_from: None,
+                        valid_until: None,
                     };
                     let _ = db.relate(edge);
                     applied += 1;
@@ -2566,6 +2823,8 @@ impl MenteDbServer {
                         edge_type: EdgeType::Supersedes,
                         weight: 1.0,
                         created_at: now,
+                        valid_from: None,
+                        valid_until: None,
                     };
                     let _ = db.relate(edge);
                     applied += 1;
@@ -2587,6 +2846,8 @@ impl MenteDbServer {
                         edge_type: *edge_type,
                         weight: *weight,
                         created_at: now,
+                        valid_from: None,
+                        valid_until: None,
                     };
                     let _ = db.relate(edge);
                     applied += 1;
@@ -2618,6 +2879,39 @@ impl MenteDbServer {
                         "action": "propagate_belief_change",
                         "root": root.to_string(),
                         "delta": delta,
+                    }));
+                }
+                mentedb_cognitive::InferredAction::InvalidateMemory {
+                    memory,
+                    superseded_by,
+                    valid_until,
+                } => {
+                    if let Some(mut mem) = existing.iter().find(|m| m.id == *memory).cloned() {
+                        mem.valid_until = Some(*valid_until);
+                        let _ = db.store(mem);
+                        applied += 1;
+                    }
+                    items.push(json!({
+                        "action": "invalidate_memory",
+                        "memory": memory.to_string(),
+                        "superseded_by": superseded_by.to_string(),
+                        "valid_until": valid_until,
+                    }));
+                }
+                mentedb_cognitive::InferredAction::UpdateContent {
+                    memory,
+                    new_content,
+                    reason,
+                } => {
+                    if let Some(mut mem) = existing.iter().find(|m| m.id == *memory).cloned() {
+                        mem.content = new_content.clone();
+                        let _ = db.store(mem);
+                        applied += 1;
+                    }
+                    items.push(json!({
+                        "action": "update_content",
+                        "memory": memory.to_string(),
+                        "reason": reason,
                     }));
                 }
             }


### PR DESCRIPTION
## Summary

Wire all 4 cognitive features from mentedb 0.4.x into the MCP server's `process_turn` handler:

### Features added
- **Bi-temporal filtering** — filter context memories by temporal validity (`is_valid_at`)
- **Topic canonicalization** — canonicalize topics before trajectory recording to reduce noise
- **Entity resolution** — resolve entities after memory storage for automatic deduplication
- **LLM contradiction verification** — verify flagged contradictions via LLM before acting on them
- **Auto belief propagation** — propagate belief changes automatically on write inference

### Other changes
- Add `CognitiveLlmService<ExtractionLlmJudge>` to server state
- Handle `InvalidateMemory` and `UpdateContent` inferred actions
- Support `MENTEDB_LLM_PROVIDER` and `MENTEDB_LLM_MODEL` env vars (via clap `env`)
- `setup` command now bakes detected LLM env vars into MCP client config
- Switch from path deps back to crates.io 0.4 releases

### Testing
- `cargo check` ✅
- `cargo fmt` ✅  
- `cargo clippy` ✅

Closes #26