### PR TITLE
fix: `update` command now overwrites existing MCP config and instructions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ enum Commands {
         #[arg(value_enum, default_value = "copilot")]
         client: SetupClient,
     },
-    /// Update agent instructions for your MCP client (same as setup, but clearer intent)
+    /// Update MCP config and agent instructions (overwrites existing entries)
     Update {
         /// Target client
         #[arg(value_enum, default_value = "copilot")]
@@ -71,8 +71,8 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::Setup { client }) => return run_setup(client),
-        Some(Commands::Update { client }) => return run_setup(client),
+        Some(Commands::Setup { client }) => return run_setup(client, false),
+        Some(Commands::Update { client }) => return run_setup(client, true),
         None => {}
     }
 
@@ -149,7 +149,7 @@ fn auto_update_instructions() {
     for path_str in &instruction_paths {
         let path = std::path::Path::new(path_str);
         if path.exists() {
-            match append_instructions(path, false) {
+            match append_instructions(path, false, false) {
                 Ok(()) => {}
                 Err(e) => {
                     tracing::warn!(path = %path.display(), error = %e, "auto-update instructions failed");
@@ -205,14 +205,14 @@ Use proactively — if the user mentions a project, search for what you know abo
 When the user says "forget" or "don't remember that", delete the memory by ID.
 "#;
 
-fn run_setup(client: SetupClient) -> anyhow::Result<()> {
+fn run_setup(client: SetupClient, force: bool) -> anyhow::Result<()> {
     let home = std::env::var("HOME").unwrap_or_else(|_| "~".to_string());
     let binary = which_mentedb_mcp();
 
     match client {
-        SetupClient::Copilot => setup_copilot(&home, &binary),
-        SetupClient::Claude => setup_claude(&home, &binary),
-        SetupClient::Cursor => setup_cursor(&home, &binary),
+        SetupClient::Copilot => setup_copilot(&home, &binary, force),
+        SetupClient::Claude => setup_claude(&home, &binary, force),
+        SetupClient::Cursor => setup_cursor(&home, &binary, force),
     }
 }
 
@@ -237,7 +237,7 @@ fn write_if_missing(path: &std::path::Path, content: &str, label: &str) -> anyho
     }
 }
 
-fn merge_mcp_config(path: &std::path::Path, binary: &str) -> anyhow::Result<()> {
+fn merge_mcp_config(path: &std::path::Path, binary: &str, force: bool) -> anyhow::Result<()> {
     let allow_list: Vec<&str> = TOOL_NAMES.to_vec();
     let mut mentedb_entry = serde_json::json!({
         "command": binary,
@@ -287,7 +287,8 @@ fn merge_mcp_config(path: &std::path::Path, binary: &str) -> anyhow::Result<()> 
         .entry("mcpServers")
         .or_insert_with(|| serde_json::json!({}));
 
-    if servers.get("mentedb").is_some() {
+    let exists = servers.get("mentedb").is_some();
+    if exists && !force {
         eprintln!("  [skip] mentedb already in MCP config: {}", path.display());
     } else {
         servers
@@ -298,13 +299,18 @@ fn merge_mcp_config(path: &std::path::Path, binary: &str) -> anyhow::Result<()> 
             std::fs::create_dir_all(parent)?;
         }
         std::fs::write(path, serde_json::to_string_pretty(&config)?)?;
-        eprintln!("  [created] MCP config: {}", path.display());
+        let verb = if exists { "updated" } else { "created" };
+        eprintln!("  [{verb}] MCP config: {}", path.display());
     }
 
     Ok(())
 }
 
-fn append_instructions(path: &std::path::Path, interactive: bool) -> anyhow::Result<()> {
+fn append_instructions(
+    path: &std::path::Path,
+    interactive: bool,
+    force: bool,
+) -> anyhow::Result<()> {
     let version_marker = format!(
         "<!-- mentedb-instructions-v{} -->",
         env!("CARGO_PKG_VERSION")
@@ -312,7 +318,7 @@ fn append_instructions(path: &std::path::Path, interactive: bool) -> anyhow::Res
 
     if path.exists() {
         let content = std::fs::read_to_string(path)?;
-        if content.contains(&version_marker) {
+        if content.contains(&version_marker) && !force {
             eprintln!(
                 "  [skip] instructions already up-to-date: {}",
                 path.display()
@@ -436,34 +442,38 @@ fn append_instructions(path: &std::path::Path, interactive: bool) -> anyhow::Res
     Ok(())
 }
 
-fn setup_copilot(home: &str, binary: &str) -> anyhow::Result<()> {
+fn setup_copilot(home: &str, binary: &str, force: bool) -> anyhow::Result<()> {
     println!("\nSetting up MenteDB for GitHub Copilot CLI...\n");
 
     let copilot_dir = std::path::PathBuf::from(home).join(".copilot");
-    merge_mcp_config(&copilot_dir.join("mcp-config.json"), binary)?;
-    append_instructions(&copilot_dir.join("copilot-instructions.md"), true)?;
+    merge_mcp_config(&copilot_dir.join("mcp-config.json"), binary, force)?;
+    append_instructions(&copilot_dir.join("copilot-instructions.md"), true, force)?;
 
     println!("\nDone! Restart Copilot CLI to activate MenteDB memory.");
     Ok(())
 }
 
-fn setup_claude(home: &str, binary: &str) -> anyhow::Result<()> {
+fn setup_claude(home: &str, binary: &str, force: bool) -> anyhow::Result<()> {
     println!("\nSetting up MenteDB for Claude Desktop...\n");
 
     let config_dir = std::path::PathBuf::from(home).join("Library/Application Support/Claude");
-    merge_mcp_config(&config_dir.join("claude_desktop_config.json"), binary)?;
+    merge_mcp_config(
+        &config_dir.join("claude_desktop_config.json"),
+        binary,
+        force,
+    )?;
 
     println!("\nDone! Restart Claude Desktop to activate MenteDB memory.");
     println!("Note: Claude Desktop reads server instructions automatically from the MCP server.");
     Ok(())
 }
 
-fn setup_cursor(home: &str, binary: &str) -> anyhow::Result<()> {
+fn setup_cursor(home: &str, binary: &str, force: bool) -> anyhow::Result<()> {
     println!("\nSetting up MenteDB for Cursor...\n");
 
     let cursor_dir = std::path::PathBuf::from(home).join(".cursor");
-    merge_mcp_config(&cursor_dir.join("mcp.json"), binary)?;
-    append_instructions(&cursor_dir.join("rules/mentedb.md"), true)?;
+    merge_mcp_config(&cursor_dir.join("mcp.json"), binary, force)?;
+    append_instructions(&cursor_dir.join("rules/mentedb.md"), true, force)?;
 
     println!("\nDone! Restart Cursor to activate MenteDB memory.");
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,10 +287,38 @@ fn merge_mcp_config(path: &std::path::Path, binary: &str, force: bool) -> anyhow
         .entry("mcpServers")
         .or_insert_with(|| serde_json::json!({}));
 
-    let exists = servers.get("mentedb").is_some();
-    if exists && !force {
+    let existing = servers.get("mentedb").cloned();
+    if existing.is_some() && !force {
         eprintln!("  [skip] mentedb already in MCP config: {}", path.display());
     } else {
+        // When updating, preserve user-configured fields (args, env) that we
+        // don't generate ourselves.  Only overwrite command and alwaysAllow.
+        if let Some(old) = &existing {
+            if let Some(old_obj) = old.as_object() {
+                let new_obj = mentedb_entry.as_object_mut().unwrap();
+                // Preserve args if the new entry has none
+                if new_obj
+                    .get("args")
+                    .and_then(|a| a.as_array())
+                    .map_or(true, |a| a.is_empty())
+                {
+                    if let Some(old_args) = old_obj.get("args") {
+                        new_obj.insert("args".to_string(), old_args.clone());
+                    }
+                }
+                // Merge env: keep old vars, overlay new ones
+                if let Some(old_env) = old_obj.get("env").and_then(|e| e.as_object()) {
+                    let new_env = new_obj
+                        .entry("env")
+                        .or_insert_with(|| serde_json::json!({}));
+                    if let Some(new_env_obj) = new_env.as_object_mut() {
+                        for (k, v) in old_env {
+                            new_env_obj.entry(k.clone()).or_insert(v.clone());
+                        }
+                    }
+                }
+            }
+        }
         servers
             .as_object_mut()
             .unwrap()
@@ -299,7 +327,11 @@ fn merge_mcp_config(path: &std::path::Path, binary: &str, force: bool) -> anyhow
             std::fs::create_dir_all(parent)?;
         }
         std::fs::write(path, serde_json::to_string_pretty(&config)?)?;
-        let verb = if exists { "updated" } else { "created" };
+        let verb = if existing.is_some() {
+            "updated"
+        } else {
+            "created"
+        };
         eprintln!("  [{verb}] MCP config: {}", path.display());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,28 +293,27 @@ fn merge_mcp_config(path: &std::path::Path, binary: &str, force: bool) -> anyhow
     } else {
         // When updating, preserve user-configured fields (args, env) that we
         // don't generate ourselves.  Only overwrite command and alwaysAllow.
-        if let Some(old) = &existing {
-            if let Some(old_obj) = old.as_object() {
-                let new_obj = mentedb_entry.as_object_mut().unwrap();
-                // Preserve args if the new entry has none
-                if new_obj
-                    .get("args")
-                    .and_then(|a| a.as_array())
-                    .map_or(true, |a| a.is_empty())
-                {
-                    if let Some(old_args) = old_obj.get("args") {
-                        new_obj.insert("args".to_string(), old_args.clone());
-                    }
-                }
-                // Merge env: keep old vars, overlay new ones
-                if let Some(old_env) = old_obj.get("env").and_then(|e| e.as_object()) {
-                    let new_env = new_obj
-                        .entry("env")
-                        .or_insert_with(|| serde_json::json!({}));
-                    if let Some(new_env_obj) = new_env.as_object_mut() {
-                        for (k, v) in old_env {
-                            new_env_obj.entry(k.clone()).or_insert(v.clone());
-                        }
+        if let Some(old) = &existing
+            && let Some(old_obj) = old.as_object()
+        {
+            let new_obj = mentedb_entry.as_object_mut().unwrap();
+            // Preserve args if the new entry has none
+            if new_obj
+                .get("args")
+                .and_then(|a| a.as_array())
+                .is_none_or(|a| a.is_empty())
+                && let Some(old_args) = old_obj.get("args")
+            {
+                new_obj.insert("args".to_string(), old_args.clone());
+            }
+            // Merge env: keep old vars, overlay new ones
+            if let Some(old_env) = old_obj.get("env").and_then(|e| e.as_object()) {
+                let new_env = new_obj
+                    .entry("env")
+                    .or_insert_with(|| serde_json::json!({}));
+                if let Some(new_env_obj) = new_env.as_object_mut() {
+                    for (k, v) in old_env {
+                        new_env_obj.entry(k.clone()).or_insert(v.clone());
                     }
                 }
             }


### PR DESCRIPTION
## Problem

`mentedb-mcp update` skips when MCP config and instructions already exist — making it behave identically to `setup`. Users expect `update` to refresh stale entries (e.g. after upgrading the binary, changing env vars, or updating tool allow-lists).

## Fix

Pass a `force` flag through the setup chain:

- **`setup`**: idempotent first-time install — skips if entry exists (unchanged behavior)
- **`update`**: always overwrites the MCP config entry and re-applies instructions, even when the version marker matches

### MCP config (`merge_mcp_config`)
- When `force=true`, replaces the existing `mentedb` entry with the current config (binary path, args, env vars, allow-list)
- Shows `[updated]` instead of `[created]` when overwriting

### Instructions (`append_instructions`)
- When `force=true`, re-applies instructions even when the version marker matches
- Still prompts interactively and creates backups if user customizations are detected