### PR TITLE
refactor: delegate cognitive tools to engine facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,8 @@ dependencies = [
 [[package]]
 name = "mentedb"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f7285f3b41b64dc5edf1042c10a2f25352d5acb46f71197a8fdf67ead142"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1704,6 +1706,8 @@ dependencies = [
 [[package]]
 name = "mentedb-cognitive"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893e7ea2dcd990acd8d90bd7cfff53ffe0816795ba2341f2818313bda9e256ce"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1719,6 +1723,8 @@ dependencies = [
 [[package]]
 name = "mentedb-consolidation"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27cd895d2e93e3a9c64ef51803ba97eefaf280c706b83444f5b39cf23d4e5cb2"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1730,6 +1736,8 @@ dependencies = [
 [[package]]
 name = "mentedb-context"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "184f9682d7580560a4b996142b9134ee5a1bf5d1b13f5bdf3f4c2b65d0dd7953"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1742,6 +1750,8 @@ dependencies = [
 [[package]]
 name = "mentedb-core"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5118839b72b388e705c5597446571fd9b329c611909846509df8355816ae9f"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1757,6 +1767,8 @@ dependencies = [
 [[package]]
 name = "mentedb-embedding"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c7f6444f09de468e3154611b96eb199618e121f04c7cb9aeea31e241ac7734"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1774,6 +1786,8 @@ dependencies = [
 [[package]]
 name = "mentedb-extraction"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f8c2909462a97fa73cf00809012c59b2c558812eef26c91da61b7f42f1b5dd1"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1790,6 +1804,8 @@ dependencies = [
 [[package]]
 name = "mentedb-graph"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674156d4f3657eb77e016c28376e435a8b2c3f4449458e1ea001fe183b3f8b8a"
 dependencies = [
  "ahash",
  "bincode",
@@ -1805,6 +1821,8 @@ dependencies = [
 [[package]]
 name = "mentedb-index"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1a5e116bd3ff2cbcab367c3206c04d2759080aa736a12d6d7a43805ca7985d"
 dependencies = [
  "ahash",
  "bincode",
@@ -1851,6 +1869,8 @@ dependencies = [
 [[package]]
 name = "mentedb-query"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c5224575cc963c6ecf29c1f46151555ec9f685901887214863eebbe4e6521f"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1862,6 +1882,8 @@ dependencies = [
 [[package]]
 name = "mentedb-storage"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f130c4331d2563e3eca718cc892b6684950f4b5324370ecc8c570f55552fad2"
 dependencies = [
  "ahash",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,11 +1684,10 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d7f946b5837c407259748d69d9e5851b16f4ef0e743d785bcbc0d47e6385a1"
+version = "0.7.0"
 dependencies = [
  "mentedb-cognitive",
+ "mentedb-consolidation",
  "mentedb-context",
  "mentedb-core",
  "mentedb-embedding",
@@ -1704,9 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd7dd2e512816f89f7cb05088c09743fd769f93feb516c193a6e46c8e6d1ec3"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1721,9 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e1895df01ec7efedfbae00f0b271577186d5f3eee5c456bd2c6c6186775123"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1734,9 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20be87c1cbcd10a911633bcadf0b7652903531183de2749172b11519fd26c5e4"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1748,9 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62cc53a00ba82259d7742b7be0fd98e80832ac7944eb8e6e166f67df8db3d39"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1765,9 +1756,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1926107bd0245c50dd702677537fe58cfca849ac27fef3fce29ec680512dabb"
+version = "0.7.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1784,9 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc938c6995c9eb6323ab89607a049acbf94ea02706d5a61786fc76bc1cf6140d"
+version = "0.7.0"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1802,9 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30524ebd864ef5349f951f37a2e6e7002cbab8f8100098e034049ab74f18ea62"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1819,9 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80f9c60c396e4954d92ffd8c0fb01d8f2dbb348382f86128f3e23e0affbd9c"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1838,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-mcp"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1867,9 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be975e0048a84155a265a1e1920958c0a04a1899e4df298280bd36789ff60e7d"
+version = "0.7.0"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1880,9 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611ed8f75d3688d620e525b3d692419b53d35e47cb3ad141a49d706d690c1b04"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,14 @@ open = "5"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 
 # Local mode dependencies (heavy - embedded DB, embeddings, LLM extraction)
-mentedb = { path = "../mentedb/crates/mentedb", optional = true }
-mentedb-core = { path = "../mentedb/crates/mentedb-core", optional = true }
-mentedb-graph = { path = "../mentedb/crates/mentedb-graph", optional = true }
-mentedb-cognitive = { path = "../mentedb/crates/mentedb-cognitive", optional = true }
-mentedb-context = { path = "../mentedb/crates/mentedb-context", optional = true }
-mentedb-embedding = { path = "../mentedb/crates/mentedb-embedding", features = ["local"], optional = true }
-mentedb-extraction = { path = "../mentedb/crates/mentedb-extraction", optional = true }
-mentedb-consolidation = { path = "../mentedb/crates/mentedb-consolidation", optional = true }
+mentedb = { version = "0.7", optional = true }
+mentedb-core = { version = "0.7", optional = true }
+mentedb-graph = { version = "0.7", optional = true }
+mentedb-cognitive = { version = "0.7", optional = true }
+mentedb-context = { version = "0.7", optional = true }
+mentedb-embedding = { version = "0.7", features = ["local"], optional = true }
+mentedb-extraction = { version = "0.7", optional = true }
+mentedb-consolidation = { version = "0.7", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mentedb-mcp"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "MCP server for MenteDB, the cognition aware database for AI agent memory"
@@ -30,14 +30,14 @@ open = "5"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 
 # Local mode dependencies (heavy - embedded DB, embeddings, LLM extraction)
-mentedb = { version = "0.6", optional = true }
-mentedb-core = { version = "0.6", optional = true }
-mentedb-graph = { version = "0.6", optional = true }
-mentedb-cognitive = { version = "0.6", optional = true }
-mentedb-context = { version = "0.6", optional = true }
-mentedb-embedding = { version = "0.6", features = ["local"], optional = true }
-mentedb-extraction = { version = "0.6", optional = true }
-mentedb-consolidation = { version = "0.6", optional = true }
+mentedb = { path = "../mentedb/crates/mentedb", optional = true }
+mentedb-core = { path = "../mentedb/crates/mentedb-core", optional = true }
+mentedb-graph = { path = "../mentedb/crates/mentedb-graph", optional = true }
+mentedb-cognitive = { path = "../mentedb/crates/mentedb-cognitive", optional = true }
+mentedb-context = { path = "../mentedb/crates/mentedb-context", optional = true }
+mentedb-embedding = { path = "../mentedb/crates/mentedb-embedding", features = ["local"], optional = true }
+mentedb-extraction = { path = "../mentedb/crates/mentedb-extraction", optional = true }
+mentedb-consolidation = { path = "../mentedb/crates/mentedb-consolidation", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 [features]

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use mentedb::MenteDb;
+use mentedb::{CognitiveConfig, MenteDb};
 use rmcp::ServiceExt;
 use rmcp::transport::io::stdio;
 
@@ -93,7 +93,7 @@ fn open_with_retry(
     delay: std::time::Duration,
 ) -> anyhow::Result<MenteDb> {
     for attempt in 1..=max_attempts {
-        match MenteDb::open(path) {
+        match MenteDb::open_with_config(path, CognitiveConfig::default()) {
             Ok(db) => return Ok(db),
             Err(e) => {
                 let msg = e.to_string();

--- a/src/tools/cognitive.rs
+++ b/src/tools/cognitive.rs
@@ -30,8 +30,7 @@ impl MenteDbServer {
             decay_rate: 0.1,
         };
 
-        let mut registry = self.pain_registry.lock().await;
-        registry.record_pain(signal);
+        self.db.record_pain(signal);
         tracing::info!(signal_id = %signal_id, memory_id = %memory_id, "pain signal recorded");
 
         Ok(CallToolResult::success(vec![Content::text(
@@ -54,8 +53,7 @@ impl MenteDbServer {
         let known = req.known_entities.unwrap_or_default();
         let turn_id = req.turn_id.unwrap_or(0);
 
-        let mut tracker = self.phantom_tracker.lock().await;
-        let phantoms = tracker.detect_gaps(&req.content, &known, turn_id);
+        let phantoms = self.db.detect_phantoms(&req.content, &known, turn_id);
 
         let items: Vec<serde_json::Value> = phantoms
             .iter()
@@ -89,8 +87,7 @@ impl MenteDbServer {
             Err(e) => return error_result(&e),
         };
 
-        let mut tracker = self.phantom_tracker.lock().await;
-        tracker.resolve(phantom_id);
+        self.db.resolve_phantom(MemoryId::from(phantom_id));
         tracing::info!(phantom_id = %phantom_id, "phantom resolved");
 
         Ok(CallToolResult::success(vec![Content::text(
@@ -126,9 +123,8 @@ impl MenteDbServer {
             timestamp: now,
         };
 
-        let mut tracker = self.trajectory_tracker.lock().await;
-        tracker.record_turn(node);
-        let trajectory_len = tracker.get_trajectory().len();
+        self.db.record_trajectory_turn(node);
+        let trajectory_len = self.db.get_trajectory().len();
         tracing::info!(
             turn_id = req.turn_id,
             trajectory_len,
@@ -149,8 +145,7 @@ impl MenteDbServer {
         description = "Predict likely next topics based on the current conversation trajectory."
     )]
     async fn predict_topics(&self) -> Result<CallToolResult, McpError> {
-        let tracker = self.trajectory_tracker.lock().await;
-        let predictions = tracker.predict_next_topics();
+        let predictions = self.db.predict_next_topics();
         tracing::info!(count = predictions.len(), "topic predictions generated");
 
         Ok(CallToolResult::success(vec![Content::text(
@@ -165,9 +160,6 @@ impl MenteDbServer {
         &self,
         Parameters(req): Parameters<DetectInterferenceRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let threshold = req.similarity_threshold.unwrap_or(0.8);
-        let detector = InterferenceDetector::new(threshold);
-
         let db = &*self.db;
         let mut memories: Vec<MemoryNode> = Vec::new();
         for id_str in &req.memory_ids {
@@ -186,7 +178,7 @@ impl MenteDbServer {
             }
         }
 
-        let pairs = detector.detect_interference(&memories);
+        let pairs = self.db.detect_interference(&memories);
         let items: Vec<serde_json::Value> = pairs
             .iter()
             .map(|p| {
@@ -212,9 +204,8 @@ impl MenteDbServer {
         &self,
         Parameters(req): Parameters<RegisterEntityRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let mut tracker = self.phantom_tracker.lock().await;
         tracing::info!(name = %req.name, entity_type = %req.entity_type, "registering entity");
-        tracker.register_entity(&req.name);
+        self.db.register_entity(&req.name);
         Ok(CallToolResult::success(vec![Content::text(
             json!({
                 "status": "registered",
@@ -229,15 +220,9 @@ impl MenteDbServer {
         description = "Get the current cognitive state including pain signals, phantom memories, and trajectory predictions."
     )]
     async fn get_cognitive_state(&self) -> Result<CallToolResult, McpError> {
-        let pain = self.pain_registry.lock().await;
-        let phantom = self.phantom_tracker.lock().await;
-        let trajectory = self.trajectory_tracker.lock().await;
-        let cache = self.speculative_cache.lock().await;
-        let cache_stats = cache.stats();
-        drop(cache);
-
-        let active_pain: Vec<serde_json::Value> = pain
-            .all_signals()
+        let active_pain: Vec<serde_json::Value> = self
+            .db
+            .all_pain_signals()
             .iter()
             .map(|s| {
                 json!({
@@ -248,7 +233,8 @@ impl MenteDbServer {
             })
             .collect();
 
-        let phantoms: Vec<serde_json::Value> = phantom
+        let phantoms: Vec<serde_json::Value> = self
+            .db
             .get_active_phantoms()
             .iter()
             .map(|p| {
@@ -259,7 +245,8 @@ impl MenteDbServer {
             })
             .collect();
 
-        let trajectory_info = trajectory.get_resume_context();
+        let trajectory_info = self.db.get_resume_context();
+        let cache_stats = self.db.speculative_cache_stats();
 
         let result = json!({
             "pain_signals": active_pain,

--- a/src/tools/consolidation.rs
+++ b/src/tools/consolidation.rs
@@ -12,53 +12,32 @@ impl MenteDbServer {
         let min_cluster_size = req.min_cluster_size.unwrap_or(2);
         let similarity_threshold = req.similarity_threshold.unwrap_or(0.85);
 
-        let db = &*self.db;
-        let all = recall_all_memories(db);
-        let memories: Vec<MemoryNode> = all.into_iter().map(|sm| sm.memory).collect();
+        let candidates = self
+            .db
+            .find_consolidation_candidates(min_cluster_size, similarity_threshold)
+            .map_err(|e| McpError::internal_error(format!("Consolidation failed: {e}"), None))?;
 
-        if memories.is_empty() {
+        if candidates.is_empty() {
             return Ok(CallToolResult::success(vec![Content::text(
-                json!({ "status": "no_memories", "clusters": [], "consolidated": [] }).to_string(),
+                json!({ "status": "no_clusters", "clusters": [], "consolidated": [] }).to_string(),
             )]));
         }
 
-        let engine = ConsolidationEngine::new();
-        let candidates = engine.find_candidates(&memories, min_cluster_size, similarity_threshold);
-
         let mut consolidated_results: Vec<serde_json::Value> = Vec::new();
         for candidate in &candidates {
-            let cluster_memories: Vec<&MemoryNode> = candidate
-                .memories
-                .iter()
-                .filter_map(|id| memories.iter().find(|m| m.id == *id))
-                .collect();
-            let cluster_owned: Vec<MemoryNode> = cluster_memories.into_iter().cloned().collect();
-            let consolidated = engine.consolidate(&cluster_owned);
-
-            // Store merged memory and remove sources
-            let agent_id = cluster_owned
-                .first()
-                .map(|m| m.agent_id)
-                .unwrap_or(AgentId(Uuid::nil()));
-            let merged = MemoryNode::new(
-                agent_id,
-                consolidated.new_type,
-                consolidated.summary.clone(),
-                consolidated.combined_embedding.clone(),
-            );
-            let _ = db.store(merged);
-            for source_id in &consolidated.source_memories {
-                let _ = db.forget(*source_id);
+            match self.db.consolidate_cluster(&candidate.memories) {
+                Ok(merged_id) => {
+                    consolidated_results.push(json!({
+                        "topic": candidate.topic,
+                        "avg_similarity": candidate.avg_similarity,
+                        "source_memory_ids": candidate.memories.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
+                        "merged_memory_id": merged_id.to_string(),
+                    }));
+                }
+                Err(e) => {
+                    tracing::warn!(topic = %candidate.topic, error = %e, "failed to consolidate cluster");
+                }
             }
-
-            consolidated_results.push(json!({
-                "topic": candidate.topic,
-                "avg_similarity": candidate.avg_similarity,
-                "source_memory_ids": candidate.memories.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
-                "merged_summary": consolidated.summary,
-                "new_type": format!("{:?}", consolidated.new_type),
-                "combined_confidence": consolidated.combined_confidence,
-            }));
         }
 
         tracing::info!(
@@ -70,7 +49,6 @@ impl MenteDbServer {
         Ok(CallToolResult::success(vec![Content::text(
             json!({
                 "status": "complete",
-                "total_memories_analyzed": memories.len(),
                 "clusters_found": candidates.len(),
                 "consolidated": consolidated_results,
             })
@@ -81,56 +59,18 @@ impl MenteDbServer {
     #[rmcp::tool(
         description = "Apply salience decay to all memories based on time and access patterns. Returns count of memories processed and those below archival threshold."
     )]
-    async fn apply_decay(
-        &self,
-        Parameters(req): Parameters<ApplyDecayRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let half_life_hours = req.half_life_hours.unwrap_or(168.0); // 7 days
-        let half_life_us = (half_life_hours * 3600.0 * 1_000_000.0) as u64;
+    async fn apply_decay(&self) -> Result<CallToolResult, McpError> {
+        let updated = self
+            .db
+            .apply_decay_global()
+            .map_err(|e| McpError::internal_error(format!("Decay failed: {e}"), None))?;
 
-        let config = DecayConfig {
-            half_life_us,
-            ..DecayConfig::default()
-        };
-        let engine = DecayEngine::new(config);
-
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_micros() as u64;
-
-        let db = &*self.db;
-        let all = recall_all_memories(db);
-        let mut memories: Vec<MemoryNode> = all.into_iter().map(|sm| sm.memory).collect();
-        let total = memories.len();
-
-        engine.apply_decay_batch(&mut memories, now);
-
-        // Persist updated salience values
-        for mem in &memories {
-            let _ = db.store(mem.clone());
-        }
-
-        let archival_threshold = 0.1;
-        let below_threshold = memories
-            .iter()
-            .filter(|m| DecayEngine::needs_archival(m, archival_threshold))
-            .count();
-
-        tracing::info!(
-            processed = total,
-            below_threshold = below_threshold,
-            half_life_hours = half_life_hours,
-            "decay applied"
-        );
+        tracing::info!(updated, "decay applied globally");
 
         Ok(CallToolResult::success(vec![Content::text(
             json!({
                 "status": "complete",
-                "memories_processed": total,
-                "below_archival_threshold": below_threshold,
-                "archival_threshold": archival_threshold,
-                "half_life_hours": half_life_hours,
+                "memories_updated": updated,
             })
             .to_string(),
         )]))
@@ -151,8 +91,7 @@ impl MenteDbServer {
         let db = &*self.db;
         match find_memory_by_id(db, id) {
             Ok(Some(sm)) => {
-                let compressor = MemoryCompressor::new();
-                let compressed = compressor.compress(&sm.memory);
+                let compressed = self.db.compress_memory(&sm.memory);
                 let original_length = sm.memory.content.len();
 
                 // Persist compressed content
@@ -186,33 +125,11 @@ impl MenteDbServer {
     #[rmcp::tool(
         description = "Evaluate all memories for archival, deletion, or consolidation decisions based on salience and age thresholds."
     )]
-    async fn evaluate_archival(
-        &self,
-        Parameters(req): Parameters<EvaluateArchivalRequest>,
-    ) -> Result<CallToolResult, McpError> {
-        let max_salience = req.salience_threshold.unwrap_or(0.1);
-        let min_age_us = req
-            .max_age_days
-            .map(|d| d * 24 * 3600 * 1_000_000)
-            .unwrap_or(7 * 24 * 3600 * 1_000_000);
-
-        let config = ArchivalConfig {
-            max_salience,
-            min_age_us,
-            ..ArchivalConfig::default()
-        };
-        let pipeline = ArchivalPipeline::new(config);
-
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_micros() as u64;
-
-        let db = &*self.db;
-        let all = recall_all_memories(db);
-        let memories: Vec<MemoryNode> = all.into_iter().map(|sm| sm.memory).collect();
-
-        let decisions = pipeline.evaluate_batch(&memories, now);
+    async fn evaluate_archival(&self) -> Result<CallToolResult, McpError> {
+        let decisions = self
+            .db
+            .evaluate_archival_global()
+            .map_err(|e| McpError::internal_error(format!("Archival eval failed: {e}"), None))?;
 
         let mut keep = Vec::new();
         let mut archive = Vec::new();
@@ -224,7 +141,7 @@ impl MenteDbServer {
             match decision {
                 ArchivalDecision::Keep => keep.push(id_str),
                 ArchivalDecision::Archive | ArchivalDecision::Delete => {
-                    let _ = db.forget(*id);
+                    let _ = self.db.forget(*id);
                     if matches!(decision, ArchivalDecision::Delete) {
                         delete.push(id_str);
                     } else {
@@ -369,7 +286,6 @@ impl MenteDbServer {
         };
 
         let engine = ForgetEngine::new();
-        // No edge listing API available; pass empty edges
         let result = engine.plan_forget(&forget_request, &memories, &[]);
 
         // Execute the actual deletion for matching memories

--- a/src/tools/handler.rs
+++ b/src/tools/handler.rs
@@ -124,12 +124,9 @@ impl ServerHandler for MenteDbServer {
         }
 
         if uri_str == "mentedb://cognitive/state" {
-            let pain = self.pain_registry.lock().await;
-            let phantom = self.phantom_tracker.lock().await;
-            let trajectory = self.trajectory_tracker.lock().await;
-
-            let active_pain: Vec<serde_json::Value> = pain
-                .get_pain_for_context(&[])
+            let active_pain: Vec<serde_json::Value> = self
+                .db
+                .all_pain_signals()
                 .iter()
                 .map(|s| {
                     json!({
@@ -140,7 +137,8 @@ impl ServerHandler for MenteDbServer {
                 })
                 .collect();
 
-            let phantoms: Vec<serde_json::Value> = phantom
+            let phantoms: Vec<serde_json::Value> = self
+                .db
                 .get_active_phantoms()
                 .iter()
                 .map(|p| {
@@ -151,7 +149,7 @@ impl ServerHandler for MenteDbServer {
                 })
                 .collect();
 
-            let trajectory_info = trajectory.get_resume_context();
+            let trajectory_info = self.db.get_resume_context();
 
             let result = json!({
                 "pain_signals": active_pain,

--- a/src/tools/inference.rs
+++ b/src/tools/inference.rs
@@ -9,8 +9,7 @@ impl MenteDbServer {
         &self,
         Parameters(req): Parameters<CheckStreamRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let stream = CognitionStream::with_config(StreamConfig::default());
-        stream.feed_token(&req.text);
+        self.db.feed_stream_token(&req.text);
 
         let facts: Vec<(MemoryId, String)> = req
             .known_facts
@@ -22,7 +21,7 @@ impl MenteDbServer {
             })
             .collect();
 
-        let alerts = stream.check_alerts(&facts);
+        let alerts = self.db.check_stream_alerts(&facts);
         let items: Vec<serde_json::Value> = alerts
             .iter()
             .map(|a| match a {
@@ -93,7 +92,7 @@ impl MenteDbServer {
             .map(|sm| sm.memory)
             .collect();
 
-        let engine = WriteInferenceEngine::new();
+        let engine = mentedb_cognitive::WriteInferenceEngine::new();
         let actions = engine.infer_on_write(&target_memory, &existing, &[]);
 
         let now = std::time::SystemTime::now()

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,15 +17,8 @@ use std::sync::Arc;
 
 use mentedb::MenteDb;
 use mentedb_cognitive::trajectory::DecisionState;
-use mentedb_cognitive::{
-    CognitionStream, CognitiveLlmService, InterferenceDetector, PainRegistry, PainSignal,
-    PhantomConfig, PhantomTracker, SpeculativeCache, StreamConfig, TrajectoryNode,
-    TrajectoryTracker, WriteInferenceEngine,
-};
-use mentedb_consolidation::{
-    ArchivalConfig, ArchivalDecision, ArchivalPipeline, ConsolidationEngine, DecayConfig,
-    DecayEngine, FactExtractor, ForgetEngine, ForgetRequest, MemoryCompressor,
-};
+use mentedb_cognitive::{CognitiveLlmService, PainSignal, TrajectoryNode};
+use mentedb_consolidation::{ArchivalDecision, FactExtractor, ForgetEngine, ForgetRequest};
 use mentedb_context::{AssemblyConfig, ContextAssembler, DeltaTracker, OutputFormat, ScoredMemory};
 use mentedb_core::edge::EdgeType;
 use mentedb_core::memory::{AttributeValue, MemoryType};
@@ -73,10 +66,6 @@ pub(crate) fn parse_decision_state(s: &str) -> DecisionState {
 pub struct MenteDbServer {
     db: Arc<MenteDb>,
     embedding_provider: Arc<dyn EmbeddingProvider>,
-    pain_registry: Arc<Mutex<PainRegistry>>,
-    phantom_tracker: Arc<Mutex<PhantomTracker>>,
-    trajectory_tracker: Arc<Mutex<TrajectoryTracker>>,
-    speculative_cache: Arc<Mutex<SpeculativeCache>>,
     delta_tracker: Arc<Mutex<DeltaTracker>>,
     /// LLM-powered cognitive service for contradiction verification,
     /// entity resolution, and topic canonicalization.
@@ -216,10 +205,6 @@ impl MenteDbServer {
         Self {
             db: Arc::new(db),
             embedding_provider,
-            pain_registry: Arc::new(Mutex::new(PainRegistry::new(100))),
-            phantom_tracker: Arc::new(Mutex::new(PhantomTracker::new(PhantomConfig::default()))),
-            trajectory_tracker: Arc::new(Mutex::new(TrajectoryTracker::new(100))),
-            speculative_cache: Arc::new(Mutex::new(SpeculativeCache::new(64, 0.5, 0.6))),
             delta_tracker: Arc::new(Mutex::new(DeltaTracker::new())),
             cognitive_llm,
             using_hash_fallback,

--- a/src/tools/process_turn_analysis.rs
+++ b/src/tools/process_turn_analysis.rs
@@ -206,15 +206,13 @@ impl MenteDbServer {
         turn_id: u64,
     ) -> (usize, usize) {
         // Phantom detection
-        let mut phantom_tracker = self.phantom_tracker.lock().await;
         let known: Vec<String> = context_items
             .iter()
             .filter_map(|ci| ci.get("content").and_then(|c| c.as_str()))
             .flat_map(|c| c.split_whitespace().map(|w| w.to_lowercase()))
             .collect();
-        let phantoms = phantom_tracker.detect_gaps(conversation, &known, turn_id);
+        let phantoms = self.db.detect_phantoms(conversation, &known, turn_id);
         let phantom_count = phantoms.len();
-        drop(phantom_tracker);
 
         // Stream contradiction check
         let known_facts: Vec<(MemoryId, String)> = context_items
@@ -227,9 +225,8 @@ impl MenteDbServer {
             })
             .collect();
         let contradiction_count = if !known_facts.is_empty() {
-            let stream = CognitionStream::with_config(StreamConfig::default());
-            stream.feed_token(assistant_resp);
-            let alerts = stream.check_alerts(&known_facts);
+            self.db.feed_stream_token(assistant_resp);
+            let alerts = self.db.check_stream_alerts(&known_facts);
             alerts
                 .iter()
                 .filter(|a| matches!(a, mentedb_cognitive::StreamAlert::Contradiction { .. }))
@@ -262,12 +259,7 @@ impl MenteDbServer {
             req.user_message.clone()
         };
         let topic_summary = if let Some(ref llm) = self.cognitive_llm {
-            let tracker = self.trajectory_tracker.lock().await;
-            let existing_topics = tracker
-                .predict_next_topics()
-                .into_iter()
-                .collect::<Vec<_>>();
-            drop(tracker);
+            let existing_topics = self.db.predict_next_topics();
             match llm.canonicalize_topic(&raw_topic, &existing_topics).await {
                 Ok(label) => {
                     tracing::debug!(raw = %raw_topic, canonical = %label.topic, "topic canonicalized");
@@ -296,10 +288,8 @@ impl MenteDbServer {
                 .unwrap_or_default()
                 .as_micros() as u64,
         };
-        let mut tracker = self.trajectory_tracker.lock().await;
-        tracker.record_turn(node);
-        let predictions: Vec<String> = tracker.predict_next_topics().into_iter().collect();
-        drop(tracker);
+        self.db.record_trajectory_turn(node);
+        let predictions: Vec<String> = self.db.predict_next_topics();
 
         // Ghost memory inference
         let speculation_indicators = [
@@ -356,23 +346,22 @@ impl MenteDbServer {
         let embed_provider = Arc::clone(&self.embedding_provider);
         let db = &*self.db;
 
-        let mut cache = self.speculative_cache.lock().await;
-        cache.pre_assemble(predictions.to_vec(), |topic| {
-            let topic_emb = embed_provider.embed(topic).ok()?;
-            let similar_ids = db.recall_similar(&topic_emb, 5).ok()?;
-            let results = resolve_memory_ids(db, &similar_ids);
-            if results.is_empty() {
-                return None;
-            }
-            let context_text = results
-                .iter()
-                .map(|sm| sm.memory.content.as_str())
-                .collect::<Vec<_>>()
-                .join("\n---\n");
-            let memory_ids: Vec<MemoryId> = results.iter().map(|sm| sm.memory.id).collect();
-            Some((context_text, memory_ids, None))
-        });
-        drop(cache);
+        self.db
+            .pre_assemble_speculative(predictions.to_vec(), |topic| {
+                let topic_emb = embed_provider.embed(topic).ok()?;
+                let similar_ids = db.recall_similar(&topic_emb, 5).ok()?;
+                let results = resolve_memory_ids(db, &similar_ids);
+                if results.is_empty() {
+                    return None;
+                }
+                let context_text = results
+                    .iter()
+                    .map(|sm| sm.memory.content.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n---\n");
+                let memory_ids: Vec<MemoryId> = results.iter().map(|sm| sm.memory.id).collect();
+                Some((context_text, memory_ids, None))
+            });
     }
 
     /// Auto-maintenance: decay, archival, consolidation on staggered intervals.
@@ -383,92 +372,56 @@ impl MenteDbServer {
 
         // Every 50 turns: apply salience decay
         if turn_id.is_multiple_of(50) {
-            let half_life_us = (168.0 * 3600.0 * 1_000_000.0) as u64;
-            let config = DecayConfig {
-                half_life_us,
-                ..DecayConfig::default()
-            };
-            let decay_engine = DecayEngine::new(config);
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_micros() as u64;
-            let db = &*self.db;
-            let all = recall_all_memories(db);
-            let mut memories: Vec<MemoryNode> = all.into_iter().map(|sm| sm.memory).collect();
-            decay_engine.apply_decay_batch(&mut memories, now);
-            for mem in &memories {
-                let _ = db.store(mem.clone());
+            match self.db.apply_decay_global() {
+                Ok(updated) => {
+                    tracing::info!(turn_id, updated, "auto-maintenance: applied salience decay");
+                }
+                Err(e) => {
+                    tracing::warn!(turn_id, error = %e, "auto-maintenance: decay failed");
+                }
             }
-            tracing::info!(turn_id, "auto-maintenance: applied salience decay");
         }
 
         // Every 100 turns: evaluate archival and delete stale memories
         if turn_id.is_multiple_of(100) {
-            let config = ArchivalConfig {
-                max_salience: 0.1,
-                min_age_us: 7 * 24 * 3600 * 1_000_000,
-                ..ArchivalConfig::default()
-            };
-            let pipeline = ArchivalPipeline::new(config);
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_micros() as u64;
-            let db = &*self.db;
-            let all = recall_all_memories(db);
-            let memories: Vec<MemoryNode> = all.into_iter().map(|sm| sm.memory).collect();
-            let decisions = pipeline.evaluate_batch(&memories, now);
-            let mut archived = 0u64;
-            for (id, decision) in &decisions {
-                if matches!(
-                    decision,
-                    ArchivalDecision::Delete | ArchivalDecision::Archive
-                ) {
-                    let _ = db.forget(*id);
-                    archived += 1;
+            match self.db.evaluate_archival_global() {
+                Ok(decisions) => {
+                    let mut archived = 0u64;
+                    for (id, decision) in &decisions {
+                        if matches!(
+                            decision,
+                            ArchivalDecision::Delete | ArchivalDecision::Archive
+                        ) {
+                            let _ = self.db.forget(*id);
+                            archived += 1;
+                        }
+                    }
+                    tracing::info!(turn_id, archived, "auto-maintenance: evaluated archival");
+                }
+                Err(e) => {
+                    tracing::warn!(turn_id, error = %e, "auto-maintenance: archival eval failed");
                 }
             }
-            tracing::info!(turn_id, archived, "auto-maintenance: evaluated archival");
         }
 
         // Every 200 turns: consolidate similar memories
         if turn_id.is_multiple_of(200) {
-            let db = &*self.db;
-            let all = recall_all_memories(db);
-            let memories: Vec<MemoryNode> = all.into_iter().map(|sm| sm.memory).collect();
-            if memories.len() >= 2 {
-                let consolidation_engine = ConsolidationEngine::new();
-                let candidates = consolidation_engine.find_candidates(&memories, 2, 0.85);
-                for candidate in &candidates {
-                    let cluster_memories: Vec<&MemoryNode> = candidate
-                        .memories
-                        .iter()
-                        .filter_map(|id| memories.iter().find(|m| m.id == *id))
-                        .collect();
-                    let cluster_owned: Vec<MemoryNode> =
-                        cluster_memories.into_iter().cloned().collect();
-                    let consolidated = consolidation_engine.consolidate(&cluster_owned);
-                    let agent_id = cluster_owned
-                        .first()
-                        .map(|m| m.agent_id)
-                        .unwrap_or(AgentId(Uuid::nil()));
-                    let merged = MemoryNode::new(
-                        agent_id,
-                        consolidated.new_type,
-                        consolidated.summary,
-                        consolidated.combined_embedding,
-                    );
-                    let _ = db.store(merged);
-                    for source_id in &consolidated.source_memories {
-                        let _ = db.forget(*source_id);
+            match self.db.find_consolidation_candidates(2, 0.85) {
+                Ok(candidates) => {
+                    for candidate in &candidates {
+                        if let Err(e) = self.db.consolidate_cluster(&candidate.memories) {
+                            tracing::warn!(error = %e, "auto-maintenance: consolidation failed for cluster");
+                        }
                     }
+                    tracing::info!(
+                        turn_id,
+                        clusters = candidates.len(),
+                        "auto-maintenance: consolidated memories"
+                    );
                 }
-                tracing::info!(
-                    turn_id,
-                    clusters = candidates.len(),
-                    "auto-maintenance: consolidated memories"
-                );
+                Err(e) => {
+                    tracing::warn!(turn_id, error = %e, "auto-maintenance: consolidation failed");
+                }
             }
         }
     }

--- a/src/tools/process_turn_helpers.rs
+++ b/src/tools/process_turn_helpers.rs
@@ -106,31 +106,45 @@ impl MenteDbServer {
     }
 
     /// §2: Check pain signals against the current user message.
+    /// Mirrors PainRegistry::get_pain_for_context: filter by keyword match, sort by relevance.
     pub(super) async fn check_pain_signals(&self, user_message: &str) -> Vec<serde_json::Value> {
         let context_words: Vec<String> = user_message
             .split_whitespace()
             .map(|w| w.to_lowercase())
             .collect();
-        // Filter pain signals by keyword match (mirroring PainRegistry::get_pain_for_context)
         let all_signals = self.db.all_pain_signals();
-        let warnings: Vec<serde_json::Value> = all_signals
+        let mut scored: Vec<_> = all_signals
             .iter()
-            .filter(|s| {
-                s.trigger_keywords.iter().any(|trigger| {
-                    context_words
-                        .iter()
-                        .any(|ctx| ctx.contains(&trigger.to_lowercase()))
-                })
+            .filter_map(|s| {
+                let matched = s
+                    .trigger_keywords
+                    .iter()
+                    .filter(|trigger| {
+                        context_words
+                            .iter()
+                            .any(|ctx| ctx.contains(&trigger.to_lowercase()))
+                    })
+                    .count();
+                if matched > 0 {
+                    let relevance = matched as f32 / s.trigger_keywords.len().max(1) as f32;
+                    let score = s.intensity * relevance;
+                    Some((s, score))
+                } else {
+                    None
+                }
             })
-            .map(|s| {
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored
+            .iter()
+            .map(|(s, _)| {
                 json!({
                     "signal_id": s.id.to_string(),
                     "intensity": s.intensity,
                     "description": &s.description,
                 })
             })
-            .collect();
-        warnings
+            .collect()
     }
 
     /// §3: Store the conversation turn as an episodic memory.

--- a/src/tools/process_turn_helpers.rs
+++ b/src/tools/process_turn_helpers.rs
@@ -10,11 +10,10 @@ impl MenteDbServer {
         query_embedding: &[f32],
         req: &ProcessTurnRequest,
     ) -> (Vec<serde_json::Value>, Vec<MemoryId>, bool) {
-        let mut cache = self.speculative_cache.lock().await;
-        let cache_result = cache
-            .try_hit(user_message, Some(query_embedding))
+        let cache_result = self
+            .db
+            .try_speculative_hit(user_message, Some(query_embedding))
             .map(|entry| (entry.memory_ids.clone(), entry.topic.clone()));
-        drop(cache);
         let cache_hit = cache_result.is_some();
 
         // Try cache first — resolve cached IDs directly without loading all memories
@@ -108,14 +107,21 @@ impl MenteDbServer {
 
     /// §2: Check pain signals against the current user message.
     pub(super) async fn check_pain_signals(&self, user_message: &str) -> Vec<serde_json::Value> {
-        let pain_registry = self.pain_registry.lock().await;
         let context_words: Vec<String> = user_message
             .split_whitespace()
             .map(|w| w.to_lowercase())
             .collect();
-        let warnings: Vec<serde_json::Value> = pain_registry
-            .get_pain_for_context(&context_words)
+        // Filter pain signals by keyword match (mirroring PainRegistry::get_pain_for_context)
+        let all_signals = self.db.all_pain_signals();
+        let warnings: Vec<serde_json::Value> = all_signals
             .iter()
+            .filter(|s| {
+                s.trigger_keywords.iter().any(|trigger| {
+                    context_words
+                        .iter()
+                        .any(|ctx| ctx.contains(&trigger.to_lowercase()))
+                })
+            })
             .map(|s| {
                 json!({
                     "signal_id": s.id.to_string(),
@@ -124,7 +130,6 @@ impl MenteDbServer {
                 })
             })
             .collect();
-        drop(pain_registry);
         warnings
     }
 
@@ -222,7 +227,7 @@ impl MenteDbServer {
             .map(|sm| sm.memory)
             .collect();
 
-        let engine = WriteInferenceEngine::new();
+        let engine = mentedb_cognitive::WriteInferenceEngine::new();
         let actions = engine.infer_on_write(&target, &existing, &[]);
 
         let now = std::time::SystemTime::now()

--- a/src/tools/types.rs
+++ b/src/tools/types.rs
@@ -118,25 +118,9 @@ pub struct ConsolidateMemoriesRequest {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct ApplyDecayRequest {
-    #[schemars(description = "Half-life in hours for salience decay (default: 168, i.e. 7 days)")]
-    pub half_life_hours: Option<f64>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
 pub struct CompressMemoryRequest {
     #[schemars(description = "UUID of the memory to compress")]
     pub id: String,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct EvaluateArchivalRequest {
-    #[schemars(
-        description = "Salience threshold below which memories are candidates for archival (default: 0.1)"
-    )]
-    pub salience_threshold: Option<f32>,
-    #[schemars(description = "Maximum age in days before considering archival (default: 7)")]
-    pub max_age_days: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -221,7 +205,8 @@ pub struct RecordTrajectoryRequest {
 pub struct DetectInterferenceRequest {
     #[schemars(description = "List of memory UUIDs to check for interference")]
     pub memory_ids: Vec<String>,
-    #[schemars(description = "Optional similarity threshold (default: 0.8)")]
+    #[schemars(description = "Similarity threshold (reserved for future use)")]
+    #[allow(dead_code)]
     pub similarity_threshold: Option<f32>,
 }
 


### PR DESCRIPTION
## Summary

Remove duplicate cognitive subsystem state from MenteDbServer. All cognitive tool handlers now delegate to the MenteDb engine's built-in subsystems (v0.7.0).

### Removed from MenteDbServer
- `pain_registry: Arc<Mutex<PainRegistry>>`
- `phantom_tracker: Arc<Mutex<PhantomTracker>>`
- `trajectory_tracker: Arc<Mutex<TrajectoryTracker>>`
- `speculative_cache: Arc<Mutex<SpeculativeCache>>`

### Delegated to engine
| MCP Tool | Before | After |
|---|---|---|
| record_pain | self.pain_registry.lock() | self.db.record_pain() |
| detect_phantoms | self.phantom_tracker.lock() | self.db.detect_phantoms() |
| resolve_phantom | self.phantom_tracker.lock() | self.db.resolve_phantom() |
| record_trajectory | self.trajectory_tracker.lock() | self.db.record_trajectory_turn() |
| predict_topics | self.trajectory_tracker.lock() | self.db.predict_next_topics() |
| detect_interference | InterferenceDetector::new() | self.db.detect_interference() |
| register_entity | self.phantom_tracker.lock() | self.db.register_entity() |
| get_cognitive_state | 4 lock().await calls | self.db.\*() direct |
| consolidate_memories | ConsolidationEngine::new() | self.db.find_consolidation_candidates() + consolidate_cluster() |
| apply_decay | DecayEngine::new() | self.db.apply_decay_global() |
| compress_memory | MemoryCompressor::new() | self.db.compress_memory() |
| evaluate_archival | ArchivalPipeline::new() | self.db.evaluate_archival_global() |
| check_stream | CognitionStream::with_config() | self.db.feed_stream_token() + check_stream_alerts() |

### Also
- DB opened with `CognitiveConfig::default()` (all subsystems enabled)
- Auto-maintenance (decay/archival/consolidation) uses engine APIs
- Removed unused `ApplyDecayRequest`, `EvaluateArchivalRequest` types
- Path deps for mentedb 0.7.0 (pending crates.io publish)
- Bumped to v0.5.0

### Stats
- 11 files changed, 155 insertions, 348 deletions (-193 net)
- All 10 integration tests pass
- Clippy clean, fmt clean