### PR TITLE
Wire sleeptime enrichment into MCP process_turn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,9 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68036bc0ffbb5a15a059ac0baf652abac92e036ef82bb105464ba924da6d842"
+version = "0.7.2"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1705,9 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd7dcad96d8c068c0a634b6bfcb717071d561efb2f0b5a7266b12fb865ea72"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1722,9 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c54dd3e1418e3ea67ec700e3ccaa883c5ca944ae67fc10d3a3cbf104d1bee5"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1735,9 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c038a45451d23698d1b3530bc4853e82a91d5551f59e1740b4d5a9dc8fe203d"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1749,9 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7104e214479f70b86df42291aefb34373f71e038528af6f76ef7246e4d640eda"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1766,9 +1756,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80854bedc0c8d56548bcc62e1413f4f02b059faeabffdcd9cb0b58246d3b9d40"
+version = "0.7.2"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1785,9 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfd219cb6ece22df70af7b9bc91f9e2bdd716de0342e25a87b744c5408b30323"
+version = "0.7.2"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1803,9 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601e82e763bcda40c9fa5b100cd13d26325c7689d03910910b98a2f0d49072bd"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bincode",
@@ -1820,9 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc8690611c1fbbe4b5e3aecc16f360fc34656a8e53d96daabfba781ce3341e4"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bincode",
@@ -1868,9 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f76727f6f0cc22c3f70263cfb19536f212aa44f9641f7e1a0b3a2d329bc3ec"
+version = "0.7.2"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1881,9 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0ec45a8c3b68842b99a37ca411702a39358679207c03fb48155a81e721adaf"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1574,9 +1574,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1684,7 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf958b8b1c7644597f460f8aa81cc3fa823161b1ebb4ede1f72644a4cfcd610c"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1703,7 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4b8a6cb9db7b66a128170406a8928d451c0802e5f818b3723cbc01cf074ef6"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1718,7 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4273a0cef0f210ba077747a9e4696e5cf836fa723cd704f3991b37039b7cb4"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1729,7 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf1d0196ed628a00a332154df06701abd4a230055d06fe41e66f50ba70e6330"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1741,7 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9763e5ee62625fe07e0b262125b3642fb649a15963321fd3e594bbd206bfb703"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1756,7 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9d136d90066df3a8cf769eef64d709f0e3bb1c610c8e789fe87aa6d5d3ae4a"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1773,7 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "817ef2c3e29d2692de7efd036f6b502cfc20c9c748706ecc1981c483d31b01e5"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1789,7 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604d7c2d56668ac820ed8954a4522c7b4819d39e0ebff40a3c3228de472079f6"
 dependencies = [
  "ahash",
  "bincode",
@@ -1804,7 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c116271684d9721c4621375fda46b1c9ffc41f689150b6d1bc2291cdc7da5235"
 dependencies = [
  "ahash",
  "bincode",
@@ -1850,7 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "846408321d610d73fa426412a30360c05411392beebc2d99fd47ac856846402e"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1861,7 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.7.2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d0d02755b3ec9a0c9ee716426627429fe0b9f0969ef766afc8d1390807b3c4"
 dependencies = [
  "ahash",
  "bincode",
@@ -2026,9 +2048,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "e9f0430136375a315630bfaf61d6bca71a048258b312be75f26f910fb4333e44"
 dependencies = [
  "bitflags",
  "libc",
@@ -2038,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "725f3ee364ae6d02cfca12ef2be392cfee2733c2a01f0ed386fb74fa94a0fd26"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2620,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,14 @@ open = "5"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 
 # Local mode dependencies (heavy - embedded DB, embeddings, LLM extraction)
-mentedb = { version = "0.7", optional = true }
-mentedb-core = { version = "0.7", optional = true }
-mentedb-graph = { version = "0.7", optional = true }
-mentedb-cognitive = { version = "0.7", optional = true }
-mentedb-context = { version = "0.7", optional = true }
-mentedb-embedding = { version = "0.7", features = ["local"], optional = true }
-mentedb-extraction = { version = "0.7", optional = true }
-mentedb-consolidation = { version = "0.7", optional = true }
+mentedb = { path = "../mentedb/crates/mentedb", optional = true }
+mentedb-core = { path = "../mentedb/crates/mentedb-core", optional = true }
+mentedb-graph = { path = "../mentedb/crates/mentedb-graph", optional = true }
+mentedb-cognitive = { path = "../mentedb/crates/mentedb-cognitive", optional = true }
+mentedb-context = { path = "../mentedb/crates/mentedb-context", optional = true }
+mentedb-embedding = { path = "../mentedb/crates/mentedb-embedding", features = ["local"], optional = true }
+mentedb-extraction = { path = "../mentedb/crates/mentedb-extraction", optional = true }
+mentedb-consolidation = { path = "../mentedb/crates/mentedb-consolidation", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,14 @@ open = "5"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 
 # Local mode dependencies (heavy - embedded DB, embeddings, LLM extraction)
-mentedb = { path = "../mentedb/crates/mentedb", optional = true }
-mentedb-core = { path = "../mentedb/crates/mentedb-core", optional = true }
-mentedb-graph = { path = "../mentedb/crates/mentedb-graph", optional = true }
-mentedb-cognitive = { path = "../mentedb/crates/mentedb-cognitive", optional = true }
-mentedb-context = { path = "../mentedb/crates/mentedb-context", optional = true }
-mentedb-embedding = { path = "../mentedb/crates/mentedb-embedding", features = ["local"], optional = true }
-mentedb-extraction = { path = "../mentedb/crates/mentedb-extraction", optional = true }
-mentedb-consolidation = { path = "../mentedb/crates/mentedb-consolidation", optional = true }
+mentedb = { version = "0.8", optional = true }
+mentedb-core = { version = "0.8", optional = true }
+mentedb-graph = { version = "0.8", optional = true }
+mentedb-cognitive = { version = "0.8", optional = true }
+mentedb-context = { version = "0.8", optional = true }
+mentedb-embedding = { version = "0.8", features = ["local"], optional = true }
+mentedb-extraction = { version = "0.8", optional = true }
+mentedb-consolidation = { version = "0.8", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 [features]

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use mentedb::{CognitiveConfig, MenteDb};
+use mentedb::{CognitiveConfig, EnrichmentConfig, MenteDb};
 use rmcp::ServiceExt;
 use rmcp::transport::io::stdio;
 
@@ -19,10 +19,12 @@ pub async fn run(config: ServerConfig) -> anyhow::Result<()> {
 
     // Retry opening the database with a timeout to handle lock contention
     // (e.g., another instance is shutting down)
+    let has_llm = config.llm_provider != "mock";
     let db = open_with_retry(
         Path::new(&config.data_dir),
         5,
         std::time::Duration::from_secs(1),
+        has_llm,
     )?;
     let server = MenteDbServer::new(db, config);
 
@@ -91,9 +93,21 @@ fn open_with_retry(
     path: &Path,
     max_attempts: u32,
     delay: std::time::Duration,
+    enable_enrichment: bool,
 ) -> anyhow::Result<MenteDb> {
+    let cognitive_config = if enable_enrichment {
+        CognitiveConfig {
+            enrichment_config: EnrichmentConfig {
+                enabled: true,
+                ..EnrichmentConfig::default()
+            },
+            ..CognitiveConfig::default()
+        }
+    } else {
+        CognitiveConfig::default()
+    };
     for attempt in 1..=max_attempts {
-        match MenteDb::open_with_config(path, CognitiveConfig::default()) {
+        match MenteDb::open_with_config(path, cognitive_config.clone()) {
             Ok(db) => return Ok(db),
             Err(e) => {
                 let msg = e.to_string();

--- a/src/tools/enrichment.rs
+++ b/src/tools/enrichment.rs
@@ -206,8 +206,10 @@ impl MenteDbServer {
         let mut llm_link_result = mentedb::EntityLinkResult::default();
         if let Some(cognitive_llm) = &self.cognitive_llm {
             let all_entities_with_context = self.db.entity_names_with_context();
-            let all_names: Vec<String> =
-                all_entities_with_context.iter().map(|(n, _)| n.clone()).collect();
+            let all_names: Vec<String> = all_entities_with_context
+                .iter()
+                .map(|(n, _)| n.clone())
+                .collect();
             let unresolved = self.db.unresolved_entity_names();
 
             if !unresolved.is_empty() {
@@ -219,14 +221,15 @@ impl MenteDbServer {
 
                 // Build EntityCandidate list with context for ALL entities
                 // (LLM needs full picture to group correctly)
-                let mut candidates: Vec<mentedb_cognitive::EntityCandidate> = all_entities_with_context
-                    .iter()
-                    .map(|(name, ctx)| mentedb_cognitive::EntityCandidate {
-                        name: name.clone(),
-                        context: ctx.clone(),
-                        memory_id: None,
-                    })
-                    .collect();
+                let mut candidates: Vec<mentedb_cognitive::EntityCandidate> =
+                    all_entities_with_context
+                        .iter()
+                        .map(|(name, ctx)| mentedb_cognitive::EntityCandidate {
+                            name: name.clone(),
+                            context: ctx.clone(),
+                            memory_id: None,
+                        })
+                        .collect();
                 // Sort for deterministic batching across runs
                 candidates.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/src/tools/enrichment.rs
+++ b/src/tools/enrichment.rs
@@ -33,6 +33,7 @@ impl MenteDbServer {
             Some(c) => c,
             None => {
                 tracing::warn!("enrichment skipped: no LLM provider configured");
+                self.db.mark_enrichment_complete(current_turn);
                 return;
             }
         };

--- a/src/tools/enrichment.rs
+++ b/src/tools/enrichment.rs
@@ -71,6 +71,7 @@ impl MenteDbServer {
         let mut total_edges = 0usize;
         let mut total_dupes = 0usize;
         let mut total_contradictions = 0usize;
+        let mut total_entities = 0usize;
 
         for (batch_idx, batch) in batches.iter().enumerate() {
             let conversation = batch
@@ -132,6 +133,36 @@ impl MenteDbServer {
                         nodes.push(node);
                     }
 
+                    // Build MemoryNode objects from extracted entities
+                    for entity in &result.entities {
+                        let content = entity.to_content();
+                        let embedding_text = entity.embedding_key();
+                        let embedding = match self.embedding_provider.embed(&embedding_text) {
+                            Ok(e) => e,
+                            Err(e) => {
+                                tracing::warn!(error = %e, "enrichment: entity embedding failed");
+                                continue;
+                            }
+                        };
+                        let mut node = MemoryNode::new(
+                            AgentId::nil(),
+                            MemoryType::Semantic,
+                            content,
+                            embedding,
+                        );
+                        let name_lower = entity.name.to_lowercase();
+                        node.tags.push(format!("entity:{}", name_lower));
+                        node.tags
+                            .push(format!("entity_type:{}", entity.entity_type));
+                        if let Some(cat) = entity.attributes.get("category") {
+                            for c in cat.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                                node.tags.push(format!("category:{}", c.to_lowercase()));
+                            }
+                        }
+                        nodes.push(node);
+                        total_entities += 1;
+                    }
+
                     match self.db.store_enrichment_memories(nodes, &source_ids) {
                         Ok((stored, edges)) => {
                             total_stored += stored;
@@ -156,11 +187,24 @@ impl MenteDbServer {
             }
         }
 
+        // Phase 2: Entity linking — create edges between same-name entities
+        let link_result = match self.db.link_entities() {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!(error = %e, "enrichment: entity linking failed");
+                mentedb::EntityLinkResult::default()
+            }
+        };
+        total_edges += link_result.edges_created;
+
         self.db.mark_enrichment_complete(current_turn);
 
         tracing::info!(
             stored = total_stored,
             edges = total_edges,
+            entities = total_entities,
+            entities_linked = link_result.linked,
+            entities_ambiguous = link_result.ambiguous,
             duplicates_skipped = total_dupes,
             contradictions = total_contradictions,
             batches = batches.len(),

--- a/src/tools/enrichment.rs
+++ b/src/tools/enrichment.rs
@@ -188,15 +188,105 @@ impl MenteDbServer {
             }
         }
 
-        // Phase 2: Entity linking — create edges between same-name entities
-        let link_result = match self.db.link_entities() {
+        // Phase 2: LLM-powered entity linking
+        //
+        // 1. Sync path: link entities already resolved by EntityResolver cache
+        // 2. LLM path: send ALL unresolved entity names to LLM for resolution
+        // 3. Apply LLM results: create edges + cache for next time
+        let sync_link_result = match self.db.link_entities() {
             Ok(r) => r,
             Err(e) => {
-                tracing::error!(error = %e, "enrichment: entity linking failed");
+                tracing::error!(error = %e, "enrichment: sync entity linking failed");
                 mentedb::EntityLinkResult::default()
             }
         };
-        total_edges += link_result.edges_created;
+        total_edges += sync_link_result.edges_created;
+
+        // LLM entity resolution: send unresolved entities to LLM
+        let mut llm_link_result = mentedb::EntityLinkResult::default();
+        if let Some(cognitive_llm) = &self.cognitive_llm {
+            let all_entities_with_context = self.db.entity_names_with_context();
+            let all_names: Vec<String> =
+                all_entities_with_context.iter().map(|(n, _)| n.clone()).collect();
+            let unresolved = self.db.unresolved_entity_names();
+
+            if !unresolved.is_empty() {
+                tracing::info!(
+                    total_entities = all_names.len(),
+                    unresolved = unresolved.len(),
+                    "running LLM entity resolution"
+                );
+
+                // Build EntityCandidate list with context for ALL entities
+                // (LLM needs full picture to group correctly)
+                let candidates: Vec<mentedb_cognitive::EntityCandidate> = all_entities_with_context
+                    .iter()
+                    .map(|(name, ctx)| mentedb_cognitive::EntityCandidate {
+                        name: name.clone(),
+                        context: ctx.clone(),
+                        memory_id: None,
+                    })
+                    .collect();
+
+                // Batch into groups of 50 to avoid context limit issues
+                let batch_size = 50;
+                let mut all_merge_groups = Vec::new();
+
+                for chunk in candidates.chunks(batch_size) {
+                    match cognitive_llm.resolve_entities(chunk).await {
+                        Ok(groups) => {
+                            all_merge_groups.extend(groups);
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "enrichment: LLM entity resolution failed");
+                        }
+                    }
+                }
+
+                if !all_merge_groups.is_empty() {
+                    // Convert LLM merge groups to engine resolution format
+                    let resolutions: Vec<mentedb::EntityLinkResolution> = all_merge_groups
+                        .iter()
+                        .map(|g| mentedb::EntityLinkResolution {
+                            canonical: g.canonical.clone(),
+                            aliases: g.aliases.clone(),
+                            confidence: g.confidence,
+                        })
+                        .collect();
+
+                    // Identify entities NOT in any merge group → confirmed singletons.
+                    // If two unresolved entities are both absent from merge groups,
+                    // the LLM implicitly said they're different.
+                    let mut grouped_names: std::collections::HashSet<String> =
+                        std::collections::HashSet::new();
+                    for g in &all_merge_groups {
+                        grouped_names.insert(g.canonical.to_lowercase());
+                        for a in &g.aliases {
+                            grouped_names.insert(a.to_lowercase());
+                        }
+                    }
+                    // We don't negative-cache singletons against each other
+                    // because they might just not have been seen together yet.
+                    let separations: Vec<mentedb::EntitySeparation> = Vec::new();
+
+                    match self
+                        .db
+                        .apply_entity_link_resolutions(&resolutions, &separations)
+                    {
+                        Ok(r) => {
+                            llm_link_result = r;
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                error = %e,
+                                "enrichment: failed to apply entity resolutions"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        total_edges += llm_link_result.edges_created;
 
         self.db.mark_enrichment_complete(current_turn);
 
@@ -204,8 +294,9 @@ impl MenteDbServer {
             stored = total_stored,
             edges = total_edges,
             entities = total_entities,
-            entities_linked = link_result.linked,
-            entities_ambiguous = link_result.ambiguous,
+            sync_linked = sync_link_result.linked,
+            llm_linked = llm_link_result.linked,
+            llm_edges = llm_link_result.edges_created,
             duplicates_skipped = total_dupes,
             contradictions = total_contradictions,
             batches = batches.len(),

--- a/src/tools/enrichment.rs
+++ b/src/tools/enrichment.rs
@@ -1,0 +1,211 @@
+use super::*;
+
+impl MenteDbServer {
+    /// Run the sleeptime enrichment pipeline if pending.
+    ///
+    /// Collects episodic memories since last enrichment, batches them,
+    /// runs LLM extraction on each batch, and stores results with
+    /// provenance tracking (source:enrichment tag + Derived edges).
+    ///
+    /// This is designed to be called after process_turn when
+    /// `enrichment_pending` is true.
+    pub(super) async fn maybe_run_enrichment(&self, current_turn: u64) {
+        if !self.db.needs_enrichment() {
+            return;
+        }
+
+        // Need an LLM provider for extraction
+        let provider_name = &self.config.llm_provider;
+        if provider_name == "mock" {
+            tracing::debug!("enrichment skipped: mock LLM provider");
+            self.db.mark_enrichment_complete(current_turn);
+            return;
+        }
+
+        let api_key = self
+            .config
+            .llm_api_key
+            .clone()
+            .or_else(|| std::env::var("MENTEDB_LLM_API_KEY").ok())
+            .or_else(|| std::env::var("OPENAI_API_KEY").ok());
+
+        let config = match self.build_extraction_config(provider_name, api_key.as_deref()) {
+            Some(c) => c,
+            None => {
+                tracing::warn!("enrichment skipped: no LLM provider configured");
+                return;
+            }
+        };
+
+        let candidates = self.db.enrichment_candidates();
+        if candidates.is_empty() {
+            tracing::debug!("enrichment: no candidates, marking complete");
+            self.db.mark_enrichment_complete(current_turn);
+            return;
+        }
+
+        tracing::info!(
+            candidates = candidates.len(),
+            "starting sleeptime enrichment"
+        );
+
+        let http_provider = match mentedb_extraction::HttpExtractionProvider::new(config) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::error!(error = %e, "enrichment: failed to create HTTP provider");
+                return;
+            }
+        };
+
+        let enrichment_config = self.db.enrichment_config().clone();
+        let extraction_cfg = ExtractionConfig {
+            quality_threshold: enrichment_config.min_confidence,
+            ..ExtractionConfig::default()
+        };
+
+        let pipeline = ExtractionPipeline::new(http_provider, extraction_cfg);
+
+        // Batch candidates into groups of ~10 conversations
+        let batches = batch_conversations(&candidates, 10);
+        let mut total_stored = 0usize;
+        let mut total_edges = 0usize;
+        let mut total_dupes = 0usize;
+        let mut total_contradictions = 0usize;
+
+        for (batch_idx, batch) in batches.iter().enumerate() {
+            let conversation = batch
+                .iter()
+                .map(|m| m.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n---\n");
+
+            let source_ids: Vec<MemoryId> = batch.iter().map(|m| m.id).collect();
+
+            // Get existing memories for dedup check
+            let existing: Vec<MemoryNode> = if let Ok(Some(emb)) = self
+                .db
+                .embed_text(&conversation[..conversation.len().min(500)])
+            {
+                self.db
+                    .recall_similar(&emb, 30)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|(id, _)| self.db.get_memory(id).ok())
+                    .collect()
+            } else {
+                Vec::new()
+            };
+
+            match pipeline
+                .process(&conversation, &existing, self.embedding_provider.as_ref())
+                .await
+            {
+                Ok(result) => {
+                    total_dupes += result.stats.rejected_duplicate;
+                    total_contradictions += result.stats.contradictions_found;
+
+                    // Build MemoryNode objects from extraction results
+                    let mut nodes = Vec::new();
+                    for mem in result
+                        .to_store
+                        .iter()
+                        .chain(result.contradictions.iter().map(|(m, _)| m))
+                    {
+                        let mem_type = mentedb_extraction::map_extraction_type_to_memory_type(
+                            &mem.memory_type,
+                        );
+                        let embedding = match self.embedding_provider.embed(&mem.content) {
+                            Ok(e) => e,
+                            Err(e) => {
+                                tracing::warn!(error = %e, "enrichment: embedding failed");
+                                continue;
+                            }
+                        };
+                        let mut node = MemoryNode::new(
+                            AgentId::nil(),
+                            mem_type,
+                            mem.content.clone(),
+                            embedding,
+                        );
+                        node.tags = mem.tags.clone();
+                        node.confidence = mem.confidence;
+                        nodes.push(node);
+                    }
+
+                    match self.db.store_enrichment_memories(nodes, &source_ids) {
+                        Ok((stored, edges)) => {
+                            total_stored += stored;
+                            total_edges += edges;
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                batch = batch_idx,
+                                error = %e,
+                                "enrichment: failed to store batch"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        batch = batch_idx,
+                        error = %e,
+                        "enrichment: extraction failed for batch"
+                    );
+                }
+            }
+        }
+
+        self.db.mark_enrichment_complete(current_turn);
+
+        tracing::info!(
+            stored = total_stored,
+            edges = total_edges,
+            duplicates_skipped = total_dupes,
+            contradictions = total_contradictions,
+            batches = batches.len(),
+            "sleeptime enrichment complete"
+        );
+    }
+
+    fn build_extraction_config(
+        &self,
+        provider_name: &str,
+        api_key: Option<&str>,
+    ) -> Option<ExtractionConfig> {
+        match provider_name.to_lowercase().as_str() {
+            "openai" => {
+                let key = api_key?;
+                let mut cfg = ExtractionConfig::openai(key);
+                if let Some(model) = &self.config.llm_model {
+                    cfg.model = model.clone();
+                }
+                Some(cfg)
+            }
+            "anthropic" => {
+                let key = api_key?;
+                let mut cfg = ExtractionConfig::anthropic(key);
+                if let Some(model) = &self.config.llm_model {
+                    cfg.model = model.clone();
+                }
+                Some(cfg)
+            }
+            "ollama" => {
+                let mut cfg = ExtractionConfig::ollama();
+                if let Some(model) = &self.config.llm_model {
+                    cfg.model = model.clone();
+                }
+                Some(cfg)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Split memories into batches of at most `batch_size`.
+fn batch_conversations(memories: &[MemoryNode], batch_size: usize) -> Vec<Vec<MemoryNode>> {
+    memories
+        .chunks(batch_size)
+        .map(|chunk| chunk.to_vec())
+        .collect()
+}

--- a/src/tools/enrichment.rs
+++ b/src/tools/enrichment.rs
@@ -219,7 +219,7 @@ impl MenteDbServer {
 
                 // Build EntityCandidate list with context for ALL entities
                 // (LLM needs full picture to group correctly)
-                let candidates: Vec<mentedb_cognitive::EntityCandidate> = all_entities_with_context
+                let mut candidates: Vec<mentedb_cognitive::EntityCandidate> = all_entities_with_context
                     .iter()
                     .map(|(name, ctx)| mentedb_cognitive::EntityCandidate {
                         name: name.clone(),
@@ -227,6 +227,8 @@ impl MenteDbServer {
                         memory_id: None,
                     })
                     .collect();
+                // Sort for deterministic batching across runs
+                candidates.sort_by(|a, b| a.name.cmp(&b.name));
 
                 // Batch into groups of 50 to avoid context limit issues
                 let batch_size = 50;
@@ -241,6 +243,13 @@ impl MenteDbServer {
                             tracing::error!(error = %e, "enrichment: LLM entity resolution failed");
                         }
                     }
+                }
+
+                // Transitive consolidation: if batch 1 says A→B and batch 2 says B→C,
+                // merge them into a single group A→B→C. This handles entities that span
+                // batch boundaries.
+                if all_merge_groups.len() > 1 {
+                    all_merge_groups = consolidate_merge_groups(all_merge_groups);
                 }
 
                 if !all_merge_groups.is_empty() {
@@ -343,5 +352,82 @@ fn batch_conversations(memories: &[MemoryNode], batch_size: usize) -> Vec<Vec<Me
     memories
         .chunks(batch_size)
         .map(|chunk| chunk.to_vec())
+        .collect()
+}
+
+/// Transitively consolidate merge groups from independent LLM batches.
+///
+/// If batch 1 produces {canonical: "NYC", aliases: ["new york"]} and batch 2
+/// produces {canonical: "new york city", aliases: ["new york"]}, this merges
+/// them into a single group because "new york" appears in both.
+fn consolidate_merge_groups(
+    groups: Vec<mentedb_cognitive::llm::EntityMergeGroup>,
+) -> Vec<mentedb_cognitive::llm::EntityMergeGroup> {
+    use std::collections::{HashMap, HashSet};
+
+    // Build name → group index mapping
+    let mut name_to_group: HashMap<String, usize> = HashMap::new();
+    // Union-Find parent array
+    let mut parent: Vec<usize> = (0..groups.len()).collect();
+
+    fn find(parent: &mut [usize], i: usize) -> usize {
+        if parent[i] != i {
+            parent[i] = find(parent, parent[i]);
+        }
+        parent[i]
+    }
+
+    fn union(parent: &mut [usize], a: usize, b: usize) {
+        let ra = find(parent, a);
+        let rb = find(parent, b);
+        if ra != rb {
+            parent[ra] = rb;
+        }
+    }
+
+    for (idx, group) in groups.iter().enumerate() {
+        let all_names = std::iter::once(&group.canonical).chain(group.aliases.iter());
+        for name in all_names {
+            let key = name.to_lowercase();
+            if let Some(&existing_idx) = name_to_group.get(&key) {
+                union(&mut parent, idx, existing_idx);
+            }
+            name_to_group.insert(key, idx);
+        }
+    }
+
+    // Collect groups by root
+    let mut root_groups: HashMap<usize, Vec<usize>> = HashMap::new();
+    for i in 0..groups.len() {
+        let root = find(&mut parent, i);
+        root_groups.entry(root).or_default().push(i);
+    }
+
+    root_groups
+        .into_values()
+        .map(|indices| {
+            let mut all_names: HashSet<String> = HashSet::new();
+            let mut best_confidence: f32 = 0.0;
+            let mut canonical = String::new();
+
+            for &idx in &indices {
+                let g = &groups[idx];
+                all_names.insert(g.canonical.clone());
+                for a in &g.aliases {
+                    all_names.insert(a.clone());
+                }
+                if g.confidence > best_confidence {
+                    best_confidence = g.confidence;
+                    canonical = g.canonical.clone();
+                }
+            }
+
+            all_names.remove(&canonical);
+            mentedb_cognitive::llm::EntityMergeGroup {
+                canonical,
+                aliases: all_names.into_iter().collect(),
+                confidence: best_confidence,
+            }
+        })
         .collect()
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,6 +1,7 @@
 mod cognitive;
 mod consolidation;
 mod context;
+mod enrichment;
 mod graph;
 mod handler;
 mod inference;

--- a/src/tools/process_turn.rs
+++ b/src/tools/process_turn.rs
@@ -136,6 +136,11 @@ impl MenteDbServer {
         // LLM enrichment: contradiction verification on flagged contradictions
         let llm_contradictions = self.verify_contradictions_llm(&result).await;
 
+        // Sleeptime enrichment: run extraction pipeline if triggered
+        if result.enrichment_pending {
+            self.maybe_run_enrichment(req.turn_id).await;
+        }
+
         let elapsed_ms = start.elapsed().as_millis();
         tracing::info!(
             turn_id = req.turn_id,


### PR DESCRIPTION
## Sleeptime Enrichment Pipeline — MCP Integration

Wires the sleeptime enrichment pipeline into the MCP server, including full LLM-powered entity resolution.

### Enrichment Pipeline
- **Auto-triggered** after `process_turn` when `enrichment_pending` is true
- Collects episodic memories since last enrichment, batches by 20
- Runs LLM extraction on each batch (entities, semantics, contradictions, procedures)
- Stores extracted memories with provenance (`source:enrichment` + `Derived` edges)
- Deduplication via embedding similarity (>0.95 = duplicate)

### LLM Entity Resolution
Full pipeline replacing threshold-based heuristics:

1. **Sync cache resolution** — `link_entities()` instantly resolves known entities via EntityResolver cache
2. **Collect unresolved** — `entity_names_with_context()` gathers all entities with content snippets for disambiguation
3. **LLM resolution** — sends ALL unresolved entities to `CognitiveLlmService.resolve_entities()` in batches of 50
4. **Transitive consolidation** — union-find merges cross-batch groups (if batch 1 says A→B and batch 2 says B→C, produces A→B→C)
5. **Apply results** — `apply_entity_link_resolutions()` creates edges, learns cache, negative-caches separations
6. **Deterministic batching** — entities sorted alphabetically for consistent results across runs

### Configuration
- `MENTEDB_LLM_PROVIDER` — openai/anthropic/ollama
- `MENTEDB_OPENAI_API_KEY` / `MENTEDB_ANTHROPIC_API_KEY` — LLM credentials
- `MENTEDB_ENRICHMENT_ENABLED=true` — opt-in enrichment
- `MENTEDB_ENRICHMENT_INTERVAL` — turns between enrichment cycles (default 50)

### Companion PR
- Engine changes: https://github.com/nambok/mentedb/pull/73