### PR TITLE
fix: ship local mode by default and add scope param to store_memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,10 @@ mentedb-consolidation = { version = "0.9", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 [features]
-default = []
+# Local mode ships by default: the README documents `npx mentedb-mcp --local`
+# and `cargo install mentedb-mcp` + `--local`, so published binaries must
+# include it. Cloud-only builds can use --no-default-features.
+default = ["local"]
 local = [
     "mentedb",
     "mentedb-core",

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can also revoke sessions from the web dashboard at [app.mentedb.com](https:/
 
 ### Claude Desktop
 
-Add to `~/.config/claude/claude_desktop_config.json` (macOS/Linux) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS), `~/.config/claude/claude_desktop_config.json` (Linux), or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
 ```json
 {
@@ -168,8 +168,9 @@ By default, the server exposes 4 essential tools:
 | `context` | Top 10 semantically relevant memories + all always-scoped memories |
 | `stored` | Number of facts auto-extracted and stored from this turn |
 | `contradictions` | Number of contradictions detected |
-| `contradiction_details` | Array of `{ memory_id, explanation }` for each contradiction |
-| `pain_warnings` | Array of `{ id, warning }` from anti_pattern memories matching current context |
+| `pain_warnings` | Array of `{ signal_id, intensity, description }` from anti_pattern memories matching current context (omitted when empty) |
+| `proactive_recalls` | Memories surfaced by detected action keywords (omitted when empty) |
+| `detected_actions` | Action keywords recognized in the turn (omitted when empty) |
 
 ### Automatic Enrichment
 

--- a/src/tools/memory.rs
+++ b/src/tools/memory.rs
@@ -38,9 +38,18 @@ impl MenteDbServer {
         let mut node = MemoryNode::new(AgentId(agent_id), memory_type, req.content, embedding);
 
         let mut tags = req.tags.unwrap_or_default();
-        // Auto-add scope tags based on content analysis
+        // Scope tag: 'always' memories are surfaced on every process_turn.
         if !tags.iter().any(|t| t.starts_with("scope:")) {
-            tags.push("scope:global".to_string());
+            let scope = match req.scope.as_deref() {
+                None | Some("contextual") => "contextual",
+                Some("always") => "always",
+                Some(other) => {
+                    return error_result(&format!(
+                        "Invalid scope '{other}' (expected 'contextual' or 'always')"
+                    ));
+                }
+            };
+            tags.push(format!("scope:{scope}"));
         }
         node.tags = tags;
 

--- a/src/tools/types.rs
+++ b/src/tools/types.rs
@@ -13,6 +13,10 @@ pub struct StoreMemoryRequest {
     pub agent_id: Option<String>,
     #[schemars(description = "Optional tags for categorization")]
     pub tags: Option<Vec<String>>,
+    #[schemars(
+        description = "Memory scope: 'contextual' (default) = retrieved by semantic similarity. 'always' = returned on every process_turn call, regardless of conversation topic."
+    )]
+    pub scope: Option<String>,
     #[schemars(description = "Optional key-value metadata")]
     pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }


### PR DESCRIPTION
## Summary

- **Local mode ships by default** (`default = ["local"]`). The README documents `npx mentedb-mcp --local`, `cargo install mentedb-mcp` + `--local`, and the 32-tool `--full-tools` surface, but every published binary was built without the `local` feature, so none of that was reachable through the documented install paths. Publishing workflows need no changes since they build with default features; cloud-only builds can use `--no-default-features`. This also means the integration test suite (gated on `feature = "local"`) now runs against the shipped configuration.
- **`store_memory` gains the `scope` parameter** ('contextual' default, 'always') matching the cloud variant and README. Previously local mode had no way to set scope and auto-tagged `scope:global`, which `process_turn` never recognized, so always-scoped memories could not work locally.
- Docs: correct macOS Claude Desktop config path (`~/Library/Application Support/Claude/...`), align the documented `process_turn` response fields with what the server actually returns.

## Test plan
- `cargo test` (now exercises the shipped default-features config): 10 passed
- `cargo clippy -- -D warnings` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)