### PR TITLE
feat: lifecycle hook integration for Claude Code with local daemon and cloud backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,6 +1855,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ local = [
 ]
 vendored-openssl = ["openssl"]
 
+[dev-dependencies]
+tempfile = "3"
+
 [profile.release]
 strip = true
 lto = true

--- a/README.md
+++ b/README.md
@@ -26,6 +26,31 @@ npx mentedb-mcp@latest login
 
 That's it. Your agent now has persistent memory that works across all your sessions and devices. Replace `copilot` with `cursor` or `claude` for other editors.
 
+### Claude Code: hooks instead of MCP (recommended)
+
+For Claude Code (the CLI), MenteDB integrates through lifecycle hooks rather than MCP tools:
+
+```bash
+npx mentedb-mcp@latest setup claude-code
+```
+
+This writes three hooks into `~/.claude/settings.json`:
+
+| Hook | What it does |
+|------|-------------|
+| `UserPromptSubmit` | Recalls context for your prompt and injects it before the model responds |
+| `Stop` | Stores the completed turn (your prompt plus the assistant's answer) through the full cognitive pipeline |
+| `SessionStart` | Injects your user profile and always-scoped memories at session start, resume, and right after context compaction |
+
+Why hooks beat MCP for memory:
+
+- Zero token overhead: no tool schemas enter the model context (MCP tool definitions cost thousands of tokens per session)
+- Deterministic: memory runs on every turn; the model never forgets to call it
+- Post-compaction recovery: the SessionStart hook re-injects standing context after Claude Code compacts, which MCP tools cannot do
+- Hooks never block: any failure is logged to `~/.mentedb/` and the turn proceeds normally
+
+The hook backend follows your login state: cloud when authenticated (each hook is a single HTTP call), otherwise a local daemon that owns the embedded database and starts automatically on first use (`mentedb-mcp daemon`). The daemon keeps the embedding model loaded and flushes to disk after every stored turn.
+
 ### How it works
 
 Once logged in, the MCP server runs as a thin HTTP client — all memory operations (store, search, recall) are handled by MenteDB Cloud. This means:
@@ -69,11 +94,13 @@ The `update` command shows you the exact instructions that will be written and a
 
 | Command | Description |
 |---------|-------------|
-| `setup <client>` | Auto-configure MCP for copilot, cursor, or claude |
+| `setup <client>` | Auto-configure copilot, cursor, claude (Desktop MCP), or claude-code (hooks) |
 | `update <client>` | Update agent instructions (preserves customizations) |
 | `login` | Authenticate with MenteDB Cloud via browser |
 | `logout` | Remove cloud credentials |
 | `status` | Check cloud connection and token validity |
+| `hook <event>` | Process a lifecycle hook: user-prompt, stop, or session-start (reads JSON from stdin) |
+| `daemon` | Run the local hook daemon (started automatically by hooks when needed) |
 
 ## Authentication
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,242 @@
+//! Local hook daemon: a long-running process that owns the embedded database
+//! and serves lifecycle hooks over localhost HTTP.
+//!
+//! Why a daemon: the Candle embedding model takes hundreds of milliseconds to
+//! load and the engine's index, graph, and cognitive state persist only on
+//! flush. A per-turn hook process would pay the model load on every prompt
+//! and race a concurrently running MCP server on flush (last writer wins).
+//! One daemon owns the database; hook invocations are thin HTTP calls.
+//!
+//! Registration: the daemon binds an ephemeral 127.0.0.1 port and writes
+//! `daemon.json` (port, pid, token) into the data directory with 0600 perms.
+//! Requests must carry the token in `x-mentedb-token`. The engine is flushed
+//! after every stored turn so a kill never loses data.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::config::ServerConfig;
+use crate::tools::{MenteDbServer, ProcessTurnRequest};
+use rmcp::handler::server::wrapper::Parameters;
+
+const DAEMON_FILE: &str = "daemon.json";
+
+/// Connection info for a running daemon, registered in the data directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonInfo {
+    pub port: u16,
+    pub pid: u32,
+    pub token: String,
+}
+
+pub fn info_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(DAEMON_FILE)
+}
+
+pub fn read_info(data_dir: &Path) -> Option<DaemonInfo> {
+    let raw = std::fs::read_to_string(info_path(data_dir)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+#[derive(Clone)]
+struct DaemonState {
+    server: Arc<MenteDbServer>,
+    token: String,
+}
+
+fn authorized(state: &DaemonState, headers: &HeaderMap) -> bool {
+    headers
+        .get("x-mentedb-token")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|t| t == state.token)
+}
+
+async fn health() -> Json<serde_json::Value> {
+    Json(json!({ "ok": true, "version": env!("CARGO_PKG_VERSION") }))
+}
+
+#[derive(Deserialize)]
+struct ContextRequest {
+    prompt: String,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+async fn context(
+    State(state): State<DaemonState>,
+    headers: HeaderMap,
+    Json(req): Json<ContextRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !authorized(&state, &headers) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    let ctx = state
+        .server
+        .hook_context(&req.prompt, req.limit.unwrap_or(8));
+    Ok(Json(ctx))
+}
+
+#[derive(Deserialize)]
+struct TurnRequest {
+    user_message: String,
+    #[serde(default)]
+    assistant_response: Option<String>,
+    turn_id: u64,
+    #[serde(default)]
+    project_context: Option<String>,
+}
+
+async fn turn(
+    State(state): State<DaemonState>,
+    headers: HeaderMap,
+    Json(req): Json<TurnRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !authorized(&state, &headers) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let result = state
+        .server
+        .process_turn(Parameters(ProcessTurnRequest {
+            user_message: req.user_message,
+            assistant_response: req.assistant_response,
+            turn_id: req.turn_id,
+            project_context: req.project_context,
+            agent_id: None,
+        }))
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "daemon process_turn failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // Durability: the engine's index, graph, and cognitive state only persist
+    // on flush; without this a daemon kill would lose the turn's links.
+    if let Err(e) = state.server.db_ref().flush() {
+        tracing::warn!(error = %e, "post-turn flush failed");
+    }
+
+    let text = result
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_default();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|_| json!({ "raw": text }));
+    Ok(Json(parsed))
+}
+
+async fn session_context(
+    State(state): State<DaemonState>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !authorized(&state, &headers) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    Ok(Json(state.server.hook_session_context()))
+}
+
+async fn daemon_health_ok(port: u16) -> bool {
+    let url = format!("http://127.0.0.1:{port}/health");
+    match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(1))
+        .build()
+    {
+        Ok(client) => client
+            .get(&url)
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false),
+        Err(_) => false,
+    }
+}
+
+/// Run the hook daemon until SIGTERM/Ctrl-C. Refuses to start when a healthy
+/// daemon is already registered for this data directory.
+pub async fn run(config: ServerConfig) -> anyhow::Result<()> {
+    let data_dir = config.data_dir.clone();
+    std::fs::create_dir_all(&data_dir)?;
+
+    if let Some(existing) = read_info(&data_dir)
+        && daemon_health_ok(existing.port).await
+    {
+        anyhow::bail!(
+            "daemon already running for {} (pid {}, port {})",
+            data_dir.display(),
+            existing.pid,
+            existing.port
+        );
+    }
+
+    let db = mentedb::MenteDb::open(&data_dir)
+        .map_err(|e| anyhow::anyhow!("failed to open database: {e}"))?;
+    let server = Arc::new(MenteDbServer::new(db, config));
+    let token = uuid::Uuid::new_v4().to_string();
+
+    let state = DaemonState {
+        server: Arc::clone(&server),
+        token: token.clone(),
+    };
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/v1/context", post(context))
+        .route("/v1/turn", post(turn))
+        .route("/v1/session-context", post(session_context))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+
+    let info = DaemonInfo {
+        port,
+        pid: std::process::id(),
+        token,
+    };
+    let info_file = info_path(&data_dir);
+    std::fs::write(&info_file, serde_json::to_string(&info)?)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&info_file, std::fs::Permissions::from_mode(0o600)).ok();
+    }
+
+    tracing::info!(port, data_dir = %data_dir.display(), "hook daemon listening");
+
+    let shutdown_server = Arc::clone(&server);
+    let shutdown_info = info_file.clone();
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            let ctrl_c = tokio::signal::ctrl_c();
+            #[cfg(unix)]
+            {
+                let mut sigterm =
+                    tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                        .expect("failed to install SIGTERM handler");
+                tokio::select! {
+                    _ = ctrl_c => {},
+                    _ = sigterm.recv() => {},
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = ctrl_c.await;
+            }
+        })
+        .await?;
+
+    if let Err(e) = shutdown_server.db_ref().close() {
+        tracing::warn!(error = %e, "database close failed during daemon shutdown");
+    }
+    std::fs::remove_file(&shutdown_info).ok();
+    tracing::info!("hook daemon stopped");
+    Ok(())
+}

--- a/src/hook/backend.rs
+++ b/src/hook/backend.rs
@@ -1,0 +1,227 @@
+//! Hook backends: cloud (single HTTP call per hook, no local engine) and
+//! local (thin client of the hook daemon, which owns the embedded database).
+//!
+//! Selection mirrors the MCP server: cloud when credentials exist and
+//! `--local` was not passed, otherwise the local daemon, auto-spawned on
+//! first use.
+
+use std::path::Path;
+
+use serde_json::json;
+
+use crate::cloud_client::CloudClient;
+
+pub enum Backend {
+    Cloud(CloudClient),
+    #[cfg(feature = "local")]
+    Local(LocalDaemonClient),
+}
+
+impl Backend {
+    pub async fn resolve(data_dir: &Path, force_local: bool) -> anyhow::Result<Self> {
+        if !force_local && let Some((api_url, token)) = crate::load_cloud_credentials() {
+            return Ok(Backend::Cloud(CloudClient::new(api_url, token)));
+        }
+
+        #[cfg(feature = "local")]
+        {
+            let client = LocalDaemonClient::connect_or_spawn(data_dir).await?;
+            Ok(Backend::Local(client))
+        }
+
+        #[cfg(not(feature = "local"))]
+        {
+            let _ = data_dir;
+            anyhow::bail!(
+                "no cloud credentials and this build has no local mode; run `mentedb-mcp login`"
+            )
+        }
+    }
+
+    /// Context for a user prompt: {memories: [...], pain: [...]}.
+    pub async fn context(&self, prompt: &str) -> anyhow::Result<serde_json::Value> {
+        match self {
+            Backend::Cloud(client) => {
+                let resp = client
+                    .call_tool("search_memories", json!({ "query": prompt, "limit": 8 }))
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                let text = resp
+                    .content
+                    .first()
+                    .map(|c| c.text.clone())
+                    .unwrap_or_default();
+                let parsed: serde_json::Value =
+                    serde_json::from_str(&text).unwrap_or_else(|_| json!({}));
+                // Normalize search_memories {results: [...]} to the hook shape.
+                let memories = parsed.get("results").cloned().unwrap_or_else(|| json!([]));
+                Ok(json!({ "memories": memories, "pain": [] }))
+            }
+            #[cfg(feature = "local")]
+            Backend::Local(client) => {
+                client
+                    .post("/v1/context", json!({ "prompt": prompt, "limit": 8 }))
+                    .await
+            }
+        }
+    }
+
+    /// Store a completed turn through the full process_turn pipeline.
+    pub async fn store_turn(
+        &self,
+        user_message: &str,
+        assistant_response: &str,
+        turn_id: u64,
+        project_context: Option<String>,
+    ) -> anyhow::Result<()> {
+        let args = json!({
+            "user_message": user_message,
+            "assistant_response": assistant_response,
+            "turn_id": turn_id,
+            "project_context": project_context,
+        });
+        match self {
+            Backend::Cloud(client) => {
+                client
+                    .call_tool("process_turn", args)
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                Ok(())
+            }
+            #[cfg(feature = "local")]
+            Backend::Local(client) => {
+                client.post("/v1/turn", args).await?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Session-start context: {profile, always: [...]}.
+    pub async fn session_context(&self) -> anyhow::Result<serde_json::Value> {
+        match self {
+            Backend::Cloud(client) => {
+                // The cloud API has no profile endpoint; surface the most
+                // relevant standing memories via search instead.
+                let resp = client
+                    .call_tool(
+                        "search_memories",
+                        json!({ "query": "user profile preferences standing rules", "limit": 10 }),
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                let text = resp
+                    .content
+                    .first()
+                    .map(|c| c.text.clone())
+                    .unwrap_or_default();
+                let parsed: serde_json::Value =
+                    serde_json::from_str(&text).unwrap_or_else(|_| json!({}));
+                let always: Vec<serde_json::Value> = parsed
+                    .get("results")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|m| m.get("content").cloned())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                Ok(json!({ "profile": null, "always": always }))
+            }
+            #[cfg(feature = "local")]
+            Backend::Local(client) => client.post("/v1/session-context", json!({})).await,
+        }
+    }
+}
+
+/// Thin HTTP client for the local hook daemon, spawning it when absent.
+#[cfg(feature = "local")]
+pub struct LocalDaemonClient {
+    port: u16,
+    token: String,
+    http: reqwest::Client,
+}
+
+#[cfg(feature = "local")]
+impl LocalDaemonClient {
+    /// Total budget for daemon startup. First-ever start downloads the
+    /// embedding model and can exceed this; the hook then serves nothing for
+    /// that turn and connects on the next one.
+    const SPAWN_WAIT: std::time::Duration = std::time::Duration::from_secs(20);
+
+    pub async fn connect_or_spawn(data_dir: &Path) -> anyhow::Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(25))
+            .build()?;
+
+        if let Some(client) = Self::try_connect(data_dir, &http).await {
+            return Ok(client);
+        }
+
+        Self::spawn_daemon(data_dir)?;
+
+        let deadline = std::time::Instant::now() + Self::SPAWN_WAIT;
+        while std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            if let Some(client) = Self::try_connect(data_dir, &http).await {
+                return Ok(client);
+            }
+        }
+        anyhow::bail!(
+            "hook daemon did not become healthy within {:?} (first start downloads the embedding model; it will be ready next turn)",
+            Self::SPAWN_WAIT
+        )
+    }
+
+    async fn try_connect(data_dir: &Path, http: &reqwest::Client) -> Option<Self> {
+        let info = crate::daemon::read_info(data_dir)?;
+        let url = format!("http://127.0.0.1:{}/health", info.port);
+        let ok = http
+            .get(&url)
+            .timeout(std::time::Duration::from_secs(1))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false);
+        if !ok {
+            return None;
+        }
+        Some(Self {
+            port: info.port,
+            token: info.token,
+            http: http.clone(),
+        })
+    }
+
+    fn spawn_daemon(data_dir: &Path) -> anyhow::Result<()> {
+        let exe: std::path::PathBuf = std::env::current_exe()?;
+        std::process::Command::new(exe)
+            .arg("--data-dir")
+            .arg(data_dir)
+            .arg("daemon")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("failed to spawn hook daemon: {e}"))?;
+        Ok(())
+    }
+
+    pub async fn post(
+        &self,
+        path: &str,
+        body: serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
+        let url = format!("http://127.0.0.1:{}{}", self.port, path);
+        let resp = self
+            .http
+            .post(&url)
+            .header("x-mentedb-token", &self.token)
+            .json(&body)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            anyhow::bail!("daemon returned HTTP {}", resp.status());
+        }
+        Ok(resp.json().await?)
+    }
+}

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -1,0 +1,319 @@
+//! Lifecycle hooks for AI clients, in the style of a PreToolUse rewrite hook:
+//! the client invokes this binary on every turn, memory happens
+//! deterministically, and no MCP tool schemas enter the model context.
+//!
+//! Claude Code events supported:
+//! - UserPromptSubmit: `hook user-prompt` reads the payload from stdin and
+//!   prints recalled context as `hookSpecificOutput.additionalContext`.
+//! - Stop: `hook stop` pairs `last_assistant_message` with the prompt stashed
+//!   at submit time and stores the completed turn through process_turn.
+//! - SessionStart: `hook session-start` prints the user profile and
+//!   always-scoped memories as plain text (re-injected after compaction).
+//!
+//! Hooks never fail the client: every error is logged to the data directory
+//! log file and the process exits 0. Output is written only on success.
+
+mod backend;
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use backend::Backend;
+
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+pub enum HookEvent {
+    /// UserPromptSubmit: inject recalled context for the prompt
+    UserPrompt,
+    /// Stop: store the completed turn
+    Stop,
+    /// SessionStart: inject profile and always-scoped memories
+    SessionStart,
+}
+
+/// Per-session state persisted across hook invocations.
+///
+/// The daemon or cloud holds all memory state; this file only carries what
+/// the split hook lifecycle needs: the monotonic turn counter and the prompt
+/// waiting for its assistant response.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct SessionState {
+    turn_id: u64,
+    pending_prompt: Option<String>,
+}
+
+fn state_path(data_dir: &Path, session_id: &str) -> PathBuf {
+    let safe: String = session_id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .take(64)
+        .collect();
+    let name = if safe.is_empty() {
+        "default".to_string()
+    } else {
+        safe
+    };
+    data_dir.join("hook_sessions").join(format!("{name}.json"))
+}
+
+fn load_state(data_dir: &Path, session_id: &str) -> SessionState {
+    std::fs::read_to_string(state_path(data_dir, session_id))
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+fn save_state(data_dir: &Path, session_id: &str, state: &SessionState) {
+    let path = state_path(data_dir, session_id);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    if let Ok(raw) = serde_json::to_string(state) {
+        std::fs::write(path, raw).ok();
+    }
+}
+
+/// Entry point for `mentedb-mcp hook <event>`. Never returns an error to the
+/// caller: hooks must not break the client.
+pub async fn run(event: HookEvent, data_dir: PathBuf, force_local: bool) -> anyhow::Result<()> {
+    if let Err(e) = run_inner(event, &data_dir, force_local).await {
+        tracing::warn!(event = ?event, error = %e, "hook failed, client unaffected");
+    }
+    Ok(())
+}
+
+async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyhow::Result<()> {
+    let mut raw = String::new();
+    std::io::stdin().read_to_string(&mut raw).ok();
+    let payload: serde_json::Value = serde_json::from_str(&raw).unwrap_or_else(|_| json!({}));
+    let session_id = payload
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("default")
+        .to_string();
+
+    match event {
+        HookEvent::UserPrompt => {
+            let prompt = payload
+                .get("prompt")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if prompt.is_empty() {
+                return Ok(());
+            }
+
+            // Stash the prompt so the Stop hook can store the complete turn.
+            let mut state = load_state(data_dir, &session_id);
+            state.pending_prompt = Some(prompt.chars().take(8_000).collect());
+            save_state(data_dir, &session_id, &state);
+
+            let backend = Backend::resolve(data_dir, force_local).await?;
+            let ctx = backend.context(&prompt).await?;
+            if let Some(text) = format_context(&ctx) {
+                println!(
+                    "{}",
+                    json!({
+                        "hookSpecificOutput": {
+                            "hookEventName": "UserPromptSubmit",
+                            "additionalContext": text,
+                        }
+                    })
+                );
+            }
+        }
+        HookEvent::Stop => {
+            let assistant = payload
+                .get("last_assistant_message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .chars()
+                .take(16_000)
+                .collect::<String>();
+
+            let mut state = load_state(data_dir, &session_id);
+            let Some(user_message) = state.pending_prompt.take() else {
+                return Ok(());
+            };
+            // turn_id starts at 1: the engine treats turn 0 as "no turn" and
+            // skips periodic maintenance for it.
+            state.turn_id += 1;
+            let turn_id = state.turn_id;
+            save_state(data_dir, &session_id, &state);
+
+            let project = payload
+                .get("cwd")
+                .and_then(|v| v.as_str())
+                .and_then(|c| Path::new(c).file_name())
+                .and_then(|n| n.to_str())
+                .map(str::to_string);
+
+            let backend = Backend::resolve(data_dir, force_local).await?;
+            backend
+                .store_turn(&user_message, &assistant, turn_id, project)
+                .await?;
+        }
+        HookEvent::SessionStart => {
+            let backend = Backend::resolve(data_dir, force_local).await?;
+            let ctx = backend.session_context().await?;
+            if let Some(text) = format_session_context(&ctx) {
+                println!("{text}");
+            }
+        }
+    }
+    Ok(())
+}
+
+const CONTEXT_CHAR_BUDGET: usize = 4_000;
+
+/// Render backend context JSON ({memories: [...], pain: [...]}) into the text
+/// injected into the model context. Returns None when there is nothing worth
+/// injecting.
+fn format_context(ctx: &serde_json::Value) -> Option<String> {
+    let memories = ctx.get("memories").and_then(|v| v.as_array());
+    let pains = ctx.get("pain").and_then(|v| v.as_array());
+
+    let mut out = String::new();
+    if let Some(memories) = memories {
+        for m in memories {
+            let content = m.get("content").and_then(|v| v.as_str()).unwrap_or("");
+            if content.is_empty() {
+                continue;
+            }
+            let mtype = m
+                .get("memory_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("memory");
+            let line = format!("- [{}] {}\n", mtype.to_lowercase(), content);
+            if out.len() + line.len() > CONTEXT_CHAR_BUDGET {
+                break;
+            }
+            out.push_str(&line);
+        }
+    }
+
+    let mut warnings = String::new();
+    if let Some(pains) = pains {
+        for p in pains {
+            let desc = p.get("description").and_then(|v| v.as_str()).unwrap_or("");
+            if desc.is_empty() {
+                continue;
+            }
+            let line = format!("- WARNING (past failure): {desc}\n");
+            if out.len() + warnings.len() + line.len() > CONTEXT_CHAR_BUDGET + 800 {
+                break;
+            }
+            warnings.push_str(&line);
+        }
+    }
+
+    if out.is_empty() && warnings.is_empty() {
+        return None;
+    }
+
+    let mut text = String::from("Relevant memories from MenteDB (persistent memory):\n");
+    text.push_str(&out);
+    if !warnings.is_empty() {
+        text.push_str(&warnings);
+    }
+    Some(text)
+}
+
+/// Render session-start JSON ({profile, always: [...]}) as plain stdout text.
+fn format_session_context(ctx: &serde_json::Value) -> Option<String> {
+    let profile = ctx.get("profile").and_then(|v| v.as_str()).unwrap_or("");
+    let always: Vec<&str> = ctx
+        .get("always")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    if profile.is_empty() && always.is_empty() {
+        return None;
+    }
+
+    let mut text = String::from("MenteDB persistent memory for this user:\n");
+    if !profile.is_empty() {
+        text.push_str("## User profile\n");
+        text.push_str(profile);
+        text.push('\n');
+    }
+    if !always.is_empty() {
+        text.push_str("## Standing rules (always apply)\n");
+        for a in always.iter().take(30) {
+            text.push_str(&format!("- {a}\n"));
+        }
+    }
+    Some(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_context_renders_memories_and_pain() {
+        let ctx = json!({
+            "memories": [
+                { "content": "User prefers Rust", "memory_type": "Semantic", "scope": "contextual" },
+            ],
+            "pain": [ { "description": "deploy without tests broke prod", "intensity": 0.9 } ],
+        });
+        let text = format_context(&ctx).unwrap();
+        assert!(text.contains("[semantic] User prefers Rust"));
+        assert!(text.contains("WARNING (past failure): deploy without tests broke prod"));
+    }
+
+    #[test]
+    fn format_context_empty_returns_none() {
+        assert!(format_context(&json!({ "memories": [], "pain": [] })).is_none());
+        assert!(format_context(&json!({})).is_none());
+    }
+
+    #[test]
+    fn format_context_respects_budget() {
+        let big = "x".repeat(1_000);
+        let memories: Vec<serde_json::Value> = (0..20)
+            .map(|_| json!({ "content": big, "memory_type": "Semantic" }))
+            .collect();
+        let text = format_context(&json!({ "memories": memories })).unwrap();
+        assert!(text.len() < CONTEXT_CHAR_BUDGET + 1_200);
+    }
+
+    #[test]
+    fn session_state_roundtrip_and_turn_counter() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = load_state(dir.path(), "abc-123");
+        assert_eq!(state.turn_id, 0);
+        state.turn_id += 1;
+        state.pending_prompt = Some("hello".into());
+        save_state(dir.path(), "abc-123", &state);
+
+        let loaded = load_state(dir.path(), "abc-123");
+        assert_eq!(loaded.turn_id, 1);
+        assert_eq!(loaded.pending_prompt.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn state_path_sanitizes_session_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = state_path(dir.path(), "../../etc/passwd");
+        assert!(path.starts_with(dir.path().join("hook_sessions")));
+        assert!(!path.to_string_lossy().contains(".."));
+    }
+
+    #[test]
+    fn format_session_context_renders_profile_and_rules() {
+        let ctx = json!({
+            "profile": "Works on trading systems",
+            "always": ["never commit secrets"],
+        });
+        let text = format_session_context(&ctx).unwrap();
+        assert!(text.contains("Works on trading systems"));
+        assert!(text.contains("never commit secrets"));
+        assert!(format_session_context(&json!({})).is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,9 @@ mod cloud_client;
 mod cloud_server;
 mod config;
 #[cfg(feature = "local")]
+mod daemon;
+mod hook;
+#[cfg(feature = "local")]
 mod resources;
 #[cfg(feature = "local")]
 mod server;
@@ -32,7 +35,7 @@ struct Cli {
     command: Option<Commands>,
 
     /// Path to the data directory
-    #[arg(long, default_value = "~/.mentedb")]
+    #[arg(long, default_value = "~/.mentedb", global = true)]
     data_dir: String,
 
     /// Embedding dimension (local mode only)
@@ -85,6 +88,15 @@ enum Commands {
     Logout,
     /// Check cloud connection status
     Status,
+    /// Process a client lifecycle hook (reads JSON payload from stdin)
+    Hook {
+        /// Hook event to process
+        #[arg(value_enum)]
+        event: hook::HookEvent,
+    },
+    /// Run the local hook daemon (owns the embedded database)
+    #[cfg(feature = "local")]
+    Daemon,
 }
 
 #[derive(Clone, clap::ValueEnum)]
@@ -92,6 +104,8 @@ enum SetupClient {
     Copilot,
     Claude,
     Cursor,
+    /// Claude Code (the CLI): lifecycle hooks, no MCP tool schemas
+    ClaudeCode,
 }
 
 #[tokio::main]
@@ -104,6 +118,40 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Login) => return run_login().await,
         Some(Commands::Logout) => return run_logout(),
         Some(Commands::Status) => return run_status().await,
+        Some(Commands::Hook { event }) => {
+            // Hooks print only their payload on stdout; logging goes to the
+            // data directory so a noisy logger can never corrupt the output
+            // the client parses.
+            let data_dir = resolve_data_dir(&cli.data_dir);
+            std::fs::create_dir_all(&data_dir).ok();
+            let file_appender = tracing_appender::rolling::daily(&data_dir, "mentedb-hook.log");
+            let (file_writer, _guard) = non_blocking(file_appender);
+            tracing_subscriber::registry()
+                .with(EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()))
+                .with(fmt::layer().with_writer(file_writer).with_ansi(false))
+                .init();
+            return hook::run(event, data_dir, cli.local).await;
+        }
+        #[cfg(feature = "local")]
+        Some(Commands::Daemon) => {
+            let data_dir = resolve_data_dir(&cli.data_dir);
+            std::fs::create_dir_all(&data_dir).ok();
+            let file_appender = tracing_appender::rolling::daily(&data_dir, "mentedb-daemon.log");
+            let (file_writer, _guard) = non_blocking(file_appender);
+            tracing_subscriber::registry()
+                .with(EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()))
+                .with(fmt::layer().with_writer(file_writer).with_ansi(false))
+                .init();
+            let config = ServerConfig::new(
+                data_dir,
+                cli.embedding_dim,
+                cli.llm_provider,
+                cli.llm_api_key,
+                cli.llm_model,
+                cli.full_tools,
+            );
+            return daemon::run(config).await;
+        }
         None => {}
     }
 
@@ -608,7 +656,107 @@ fn run_setup(client: SetupClient, force: bool) -> anyhow::Result<()> {
         SetupClient::Copilot => setup_copilot(&home, &binary, force),
         SetupClient::Claude => setup_claude(&home, &binary, force),
         SetupClient::Cursor => setup_cursor(&home, &binary, force),
+        SetupClient::ClaudeCode => setup_claude_code(&home, &binary, force),
     }
+}
+
+/// Configure Claude Code (the CLI) with lifecycle hooks instead of MCP.
+///
+/// Hooks cost zero tool-schema tokens and run deterministically every turn:
+/// UserPromptSubmit injects recalled context, Stop stores the completed turn,
+/// SessionStart injects the user profile (including right after compaction).
+fn setup_claude_code(home: &str, binary: &str, force: bool) -> anyhow::Result<()> {
+    println!("\nSetting up MenteDB hooks for Claude Code...\n");
+
+    let settings_path = std::path::PathBuf::from(home).join(".claude/settings.json");
+    let hook_command = if binary == "npx" {
+        "npx -y mentedb-mcp@latest hook".to_string()
+    } else {
+        format!("{binary} hook")
+    };
+
+    let raw = std::fs::read_to_string(&settings_path).unwrap_or_else(|_| "{}".to_string());
+    let mut settings: serde_json::Value =
+        serde_json::from_str(&raw).unwrap_or_else(|_| serde_json::json!({}));
+    if !settings.is_object() {
+        settings = serde_json::json!({});
+    }
+
+    let hooks = settings
+        .as_object_mut()
+        .expect("settings is an object")
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}));
+    if !hooks.is_object() {
+        *hooks = serde_json::json!({});
+    }
+
+    let events: [(&str, &str, &str); 3] = [
+        ("UserPromptSubmit", "user-prompt", ""),
+        ("Stop", "stop", ""),
+        ("SessionStart", "session-start", "startup|resume|compact"),
+    ];
+
+    for (event, subcommand, matcher) in events {
+        let command = format!("{hook_command} {subcommand}");
+        let entries = hooks
+            .as_object_mut()
+            .expect("hooks is an object")
+            .entry(event)
+            .or_insert_with(|| serde_json::json!([]));
+        if !entries.is_array() {
+            *entries = serde_json::json!([]);
+        }
+        let arr = entries.as_array_mut().expect("entries is an array");
+
+        let already = arr.iter().any(|group| {
+            group["hooks"].as_array().is_some_and(|hs| {
+                hs.iter().any(|h| {
+                    h["command"]
+                        .as_str()
+                        .is_some_and(|c| c.contains("mentedb-mcp") && c.contains(subcommand))
+                })
+            })
+        });
+        if already && !force {
+            eprintln!("  [skip] {event} hook already configured");
+            continue;
+        }
+        if already && force {
+            arr.retain(|group| {
+                !group["hooks"].as_array().is_some_and(|hs| {
+                    hs.iter().any(|h| {
+                        h["command"]
+                            .as_str()
+                            .is_some_and(|c| c.contains("mentedb-mcp"))
+                    })
+                })
+            });
+        }
+
+        let mut group = serde_json::json!({
+            "hooks": [ { "type": "command", "command": command } ]
+        });
+        if !matcher.is_empty() {
+            group["matcher"] = serde_json::json!(matcher);
+        }
+        arr.push(group);
+        eprintln!("  [added] {event} hook");
+    }
+
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&settings_path, serde_json::to_string_pretty(&settings)?)?;
+    eprintln!("  [updated] {}", settings_path.display());
+
+    println!("\nDone. MenteDB now runs on every Claude Code turn via hooks:");
+    println!("  UserPromptSubmit  recalls context for the prompt");
+    println!("  Stop              stores the completed turn");
+    println!("  SessionStart      injects your profile and standing rules");
+    println!("\nBackend: cloud when logged in (mentedb-mcp login), otherwise a");
+    println!("local daemon that starts automatically on first use.");
+    Ok(())
 }
 
 fn which_mentedb_mcp() -> String {

--- a/src/tools/hook_support.rs
+++ b/src/tools/hook_support.rs
@@ -1,0 +1,73 @@
+//! Engine-backed helpers for the lifecycle hook daemon.
+//!
+//! These run inside the daemon process, which is the single owner of the
+//! local database, so hooks and any MCP stdio clients never race on the
+//! engine's in-memory index and cognitive state.
+
+use super::*;
+
+fn now_us() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros() as u64
+}
+
+impl MenteDbServer {
+    /// Recall context for a user prompt: hybrid search plus always-scoped
+    /// memories plus pain warnings. Read-only, used by the UserPromptSubmit
+    /// hook so nothing is stored until the turn completes.
+    pub(crate) fn hook_context(&self, prompt: &str, k: usize) -> serde_json::Value {
+        let db = &*self.db;
+        let embedding = self.embedding_provider.embed(prompt).unwrap_or_default();
+
+        let hits = db
+            .recall_hybrid_at(&embedding, Some(prompt), k, now_us(), None, None)
+            .unwrap_or_default();
+        let mut memories = resolve_memory_ids(db, &hits);
+
+        // Always-scoped memories are served every turn regardless of similarity.
+        let seen: std::collections::HashSet<MemoryId> =
+            memories.iter().map(|sm| sm.memory.id).collect();
+        for sm in recall_all_memories(db) {
+            if sm.memory.tags.iter().any(|t| t == "scope:always") && !seen.contains(&sm.memory.id) {
+                memories.push(sm);
+            }
+        }
+
+        let keywords: Vec<String> = prompt
+            .split_whitespace()
+            .map(|w| w.to_lowercase())
+            .collect();
+        let pains = db.get_pain_warnings(&keywords);
+
+        json!({
+            "memories": memories
+                .iter()
+                .map(|sm| json!({
+                    "content": sm.memory.content,
+                    "memory_type": format!("{:?}", sm.memory.memory_type),
+                    "scope": if sm.memory.tags.iter().any(|t| t == "scope:always") { "always" } else { "contextual" },
+                }))
+                .collect::<Vec<_>>(),
+            "pain": pains
+                .iter()
+                .map(|p| json!({ "description": p.description, "intensity": p.intensity }))
+                .collect::<Vec<_>>(),
+        })
+    }
+
+    /// Session-start context: the accumulated user profile plus every
+    /// always-scoped memory.
+    pub(crate) fn hook_session_context(&self) -> serde_json::Value {
+        let db = &*self.db;
+        let profile = db.user_profile().map(|m| m.content);
+        let always: Vec<String> = recall_all_memories(db)
+            .into_iter()
+            .filter(|sm| sm.memory.tags.iter().any(|t| t == "scope:always"))
+            .map(|sm| sm.memory.content)
+            .collect();
+
+        json!({ "profile": profile, "always": always })
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -4,6 +4,7 @@ mod context;
 mod enrichment;
 mod graph;
 mod handler;
+mod hook_support;
 mod inference;
 mod ingest;
 mod memory;

--- a/src/tools/process_turn.rs
+++ b/src/tools/process_turn.rs
@@ -91,7 +91,7 @@ impl MenteDbServer {
     #[rmcp::tool(
         description = "Process a conversation turn. Stores new memories and returns relevant context from past conversations. MUST be called every turn."
     )]
-    async fn process_turn(
+    pub(crate) async fn process_turn(
         &self,
         Parameters(req): Parameters<ProcessTurnRequest>,
     ) -> Result<CallToolResult, McpError> {

--- a/tests/hook_e2e.rs
+++ b/tests/hook_e2e.rs
@@ -1,0 +1,305 @@
+//! End-to-end tests for the lifecycle hook integration: daemon HTTP surface,
+//! hook binary stdin/stdout contract, and the full prompt -> stop -> recall
+//! loop against a real embedded database.
+#![cfg(feature = "local")]
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const BIN: &str = env!("CARGO_BIN_EXE_mentedb-mcp");
+
+#[derive(serde::Deserialize)]
+struct DaemonInfo {
+    port: u16,
+    pid: u32,
+    token: String,
+}
+
+/// Kills the daemon (spawned directly or by hook auto-spawn) on drop.
+struct DaemonGuard {
+    child: Option<Child>,
+    data_dir: PathBuf,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        if let Some(info) = read_info(&self.data_dir) {
+            let _ = Command::new("kill").arg(info.pid.to_string()).status();
+        }
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn read_info(data_dir: &Path) -> Option<DaemonInfo> {
+    let raw = std::fs::read_to_string(data_dir.join("daemon.json")).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn wait_for_daemon(data_dir: &Path, timeout: Duration) -> DaemonInfo {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Some(info) = read_info(data_dir) {
+            let health = ureq_get(&format!("http://127.0.0.1:{}/health", info.port));
+            if health.is_some() {
+                return info;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    panic!("daemon did not become healthy within {timeout:?}");
+}
+
+fn ureq_get(url: &str) -> Option<String> {
+    let output = Command::new("curl")
+        .args(["-s", "-f", "-m", "2", url])
+        .output()
+        .ok()?;
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        None
+    }
+}
+
+fn daemon_post(info: &DaemonInfo, path: &str, body: &serde_json::Value) -> (u32, String) {
+    let output = Command::new("curl")
+        .args([
+            "-s",
+            "-m",
+            "30",
+            "-o",
+            "-",
+            "-w",
+            "\n%{http_code}",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-H",
+            &format!("x-mentedb-token: {}", info.token),
+            "-d",
+            &body.to_string(),
+            &format!("http://127.0.0.1:{}{}", info.port, path),
+        ])
+        .output()
+        .expect("curl failed");
+    let raw = String::from_utf8_lossy(&output.stdout).to_string();
+    let (body, code) = raw.rsplit_once('\n').unwrap_or(("", "0"));
+    (code.trim().parse().unwrap_or(0), body.to_string())
+}
+
+fn run_hook(data_dir: &Path, event: &str, payload: &serde_json::Value) -> String {
+    let mut child = Command::new(BIN)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "--local",
+            "hook",
+            event,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to run hook");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(payload.to_string().as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("hook did not exit");
+    assert!(
+        output.status.success(),
+        "hook must always exit 0, got {:?}",
+        output.status
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn spawn_daemon(data_dir: &Path) -> DaemonGuard {
+    let child = Command::new(BIN)
+        .args(["--data-dir", data_dir.to_str().unwrap(), "daemon"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn daemon");
+    DaemonGuard {
+        child: Some(child),
+        data_dir: data_dir.to_path_buf(),
+    }
+}
+
+#[test]
+fn daemon_serves_turn_and_context_with_auth() {
+    let dir = tempfile::tempdir().unwrap();
+    let _guard = spawn_daemon(dir.path());
+    let info = wait_for_daemon(dir.path(), Duration::from_secs(120));
+
+    // Unauthorized without the token.
+    let output = Command::new("curl")
+        .args([
+            "-s",
+            "-o",
+            "/dev/null",
+            "-w",
+            "%{http_code}",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            "{\"prompt\":\"x\"}",
+            &format!("http://127.0.0.1:{}/v1/context", info.port),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "401");
+
+    // Store a turn through the full pipeline.
+    let (code, body) = daemon_post(
+        &info,
+        "/v1/turn",
+        &serde_json::json!({
+            "user_message": "I always deploy with blue green releases on Fridays",
+            "assistant_response": "Noted, blue green on Fridays.",
+            "turn_id": 1,
+        }),
+    );
+    assert_eq!(code, 200, "turn failed: {body}");
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["ok"], true);
+
+    // Recall it.
+    let (code, body) = daemon_post(
+        &info,
+        "/v1/context",
+        &serde_json::json!({ "prompt": "how do I deploy releases" }),
+    );
+    assert_eq!(code, 200);
+    let ctx: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let memories = ctx["memories"].as_array().unwrap();
+    assert!(
+        memories
+            .iter()
+            .any(|m| m["content"].as_str().unwrap_or("").contains("blue green")),
+        "stored turn must be recallable, got: {ctx}"
+    );
+}
+
+#[test]
+fn hook_full_turn_loop_with_autospawn() {
+    let dir = tempfile::tempdir().unwrap();
+    // No daemon started: the first hook call must auto-spawn it.
+    let guard = DaemonGuard {
+        child: None,
+        data_dir: dir.path().to_path_buf(),
+    };
+
+    let session = "sess-hook-e2e";
+
+    // Turn 1: user prompt (stashes prompt, may return no context on an empty DB).
+    let _ = run_hook(
+        dir.path(),
+        "user-prompt",
+        &serde_json::json!({
+            "session_id": session,
+            "prompt": "remember that my project codename is nightjar",
+            "hook_event_name": "UserPromptSubmit",
+        }),
+    );
+    // The auto-spawned daemon may still be loading on the very first call;
+    // wait until it registers before the stop hook.
+    let _info = wait_for_daemon(dir.path(), Duration::from_secs(120));
+
+    // Retry the prompt hook now that the daemon is up (first call may have
+    // timed out waiting on model download).
+    let _ = run_hook(
+        dir.path(),
+        "user-prompt",
+        &serde_json::json!({
+            "session_id": session,
+            "prompt": "remember that my project codename is nightjar",
+            "hook_event_name": "UserPromptSubmit",
+        }),
+    );
+
+    // Stop hook: stores the turn.
+    let out = run_hook(
+        dir.path(),
+        "stop",
+        &serde_json::json!({
+            "session_id": session,
+            "last_assistant_message": "Got it, codename nightjar.",
+            "hook_event_name": "Stop",
+        }),
+    );
+    assert!(out.trim().is_empty(), "stop hook must print nothing: {out}");
+
+    // Session state advanced.
+    let state_raw =
+        std::fs::read_to_string(dir.path().join(format!("hook_sessions/{session}.json"))).unwrap();
+    let state: serde_json::Value = serde_json::from_str(&state_raw).unwrap();
+    assert_eq!(state["turn_id"], 1);
+    assert!(state["pending_prompt"].is_null());
+
+    // Turn 2: the prompt hook must now recall the stored turn as context.
+    let out = run_hook(
+        dir.path(),
+        "user-prompt",
+        &serde_json::json!({
+            "session_id": session,
+            "prompt": "what is my project codename",
+            "hook_event_name": "UserPromptSubmit",
+        }),
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(out.trim()).expect("hook must print valid JSON when it has context");
+    let ctx = parsed["hookSpecificOutput"]["additionalContext"]
+        .as_str()
+        .expect("additionalContext present");
+    assert_eq!(
+        parsed["hookSpecificOutput"]["hookEventName"],
+        "UserPromptSubmit"
+    );
+    assert!(
+        ctx.contains("nightjar"),
+        "recalled context must contain the stored fact, got: {ctx}"
+    );
+
+    drop(guard);
+}
+
+#[test]
+fn hook_tolerates_garbage_input() {
+    let dir = tempfile::tempdir().unwrap();
+    // Malformed JSON, no daemon, no cloud: must still exit 0 with no output.
+    let mut child = Command::new(BIN)
+        .args([
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+            "--local",
+            "hook",
+            "stop",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"this is not json")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+}


### PR DESCRIPTION
## Summary

RTK-style integration: instead of MCP tool schemas (7-15k tokens per session, model must remember to call them), Claude Code invokes `mentedb-mcp hook <event>` on every turn via lifecycle hooks. Zero token overhead, deterministic memory, and post-compaction context recovery.

### Hook commands
- `hook user-prompt` (UserPromptSubmit): reads the payload from stdin, recalls context (hybrid search + always-scoped memories + pain warnings), prints it as `hookSpecificOutput.additionalContext`, and stashes the prompt for the stop hook
- `hook stop` (Stop): pairs the stashed prompt with `last_assistant_message` and stores the completed turn through the full process_turn pipeline; per-session monotonic turn_id (starts at 1 so engine maintenance actually fires)
- `hook session-start` (SessionStart, matcher `startup|resume|compact`): prints the user profile and standing rules, re-injected right after compaction

Hooks never fail the client: every error is logged under the data dir and the process exits 0 with no output.

### Backends (both in this PR)
- Cloud: each hook is a single authenticated HTTP call (search_memories / process_turn); no local engine, no model load
- Local: a new `daemon` subcommand owns the embedded database and serves hooks over localhost HTTP (ephemeral port + bearer token in `daemon.json`, 0600). Hooks auto-spawn it on first use. The daemon keeps the Candle model loaded (a per-turn process would pay the load every prompt) and flushes the engine after every stored turn, so a kill loses nothing. Single-owner design removes the index/graph last-writer-wins race between concurrent engine processes.
- Selection mirrors the MCP server: cloud when logged in and `--local` not passed

### Setup
`setup claude-code` merges the three hooks into `~/.claude/settings.json`, preserving existing hooks and settings; idempotent, `update` re-writes.

## Test plan
- 19 tests pass (6 hook unit tests, 3 end-to-end: daemon auth/turn/recall over HTTP, full prompt-to-stop-to-recall loop through the real binary with auto-spawn, garbage-input tolerance)
- clippy -D warnings clean on default and --no-default-features builds
- Manual: `setup claude-code` against a scratch HOME preserves an existing rtk PreToolUse hook and is idempotent on rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)