### PR TITLE
feat: redaction, offline spool, sync, doctor, and hook pipeline hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,6 +1850,7 @@ dependencies = [
  "mentedb-graph",
  "open",
  "openssl",
+ "regex",
  "reqwest",
  "rmcp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
 uuid = { version = "1", features = ["v4"] }
+regex = "1"
 schemars = "1"
 axum = { version = "0.7", features = ["json"] }
 open = "5"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -183,6 +183,44 @@ async fn flush(
     Ok(Json(json!({ "ok": true })))
 }
 
+/// Dump every memory for `mentedb-mcp sync` (local to cloud migration).
+async fn export(
+    State(state): State<DaemonState>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !authorized(&state, &headers) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    let db = state.server.db_ref();
+    let memories: Vec<serde_json::Value> = db
+        .memory_ids()
+        .into_iter()
+        .filter_map(|id| db.get_memory(id).ok())
+        .map(|n| {
+            json!({
+                "id": n.id.to_string(),
+                "content": n.content,
+                "memory_type": memory_type_str(&n.memory_type),
+                "tags": n.tags,
+                "created_at": n.created_at,
+            })
+        })
+        .collect();
+    Ok(Json(json!({ "memories": memories })))
+}
+
+fn memory_type_str(mt: &mentedb::prelude::MemoryType) -> &'static str {
+    use mentedb::prelude::MemoryType;
+    match mt {
+        MemoryType::Episodic => "episodic",
+        MemoryType::Semantic => "semantic",
+        MemoryType::Procedural => "procedural",
+        MemoryType::Correction => "correction",
+        MemoryType::AntiPattern => "anti_pattern",
+        MemoryType::Reasoning => "reasoning",
+    }
+}
+
 async fn daemon_health_ok(port: u16) -> bool {
     let url = format!("http://127.0.0.1:{port}/health");
     match reqwest::Client::builder()
@@ -232,6 +270,7 @@ pub async fn run(config: ServerConfig) -> anyhow::Result<()> {
         .route("/v1/note", post(note))
         .route("/v1/flush", post(flush))
         .route("/v1/session-context", post(session_context))
+        .route("/v1/export", post(export))
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
@@ -242,13 +281,25 @@ pub async fn run(config: ServerConfig) -> anyhow::Result<()> {
         pid: std::process::id(),
         token,
     };
+    // The registration file carries the auth token: it must never exist
+    // world-readable, so create it 0600 from the first byte.
     let info_file = info_path(&data_dir);
-    std::fs::write(&info_file, serde_json::to_string(&info)?)?;
     #[cfg(unix)]
     {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&info_file)?;
+        f.write_all(serde_json::to_string(&info)?.as_bytes())?;
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&info_file, std::fs::Permissions::from_mode(0o600)).ok();
     }
+    #[cfg(not(unix))]
+    std::fs::write(&info_file, serde_json::to_string(&info)?)?;
 
     tracing::info!(port, data_dir = %data_dir.display(), "hook daemon listening");
 

--- a/src/hook/backend.rs
+++ b/src/hook/backend.rs
@@ -154,8 +154,22 @@ impl Backend {
     pub async fn session_context(&self) -> anyhow::Result<serde_json::Value> {
         match self {
             Backend::Cloud(client) => {
-                // The cloud API has no profile endpoint; surface the most
-                // relevant standing memories via search instead.
+                // Prefer the dedicated tool: it returns scope:always memories
+                // deterministically instead of hoping a search matches them.
+                if let Ok(resp) = client.call_tool("get_session_context", json!({})).await {
+                    let text = resp
+                        .content
+                        .first()
+                        .map(|c| c.text.clone())
+                        .unwrap_or_default();
+                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text)
+                        && (parsed.get("always").is_some() || parsed.get("profile").is_some())
+                    {
+                        return Ok(parsed);
+                    }
+                }
+
+                // Fallback for older gateways without the tool.
                 let resp = client
                     .call_tool(
                         "search_memories",
@@ -171,7 +185,8 @@ impl Backend {
                 let parsed: serde_json::Value =
                     serde_json::from_str(&text).unwrap_or_else(|_| json!({}));
                 let always: Vec<serde_json::Value> = parsed
-                    .get("results")
+                    .get("memories")
+                    .or_else(|| parsed.get("results"))
                     .and_then(|v| v.as_array())
                     .map(|arr| {
                         arr.iter()

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -13,7 +13,9 @@
 //! Hooks never fail the client: every error is logged to the data directory
 //! log file and the process exits 0. Output is written only on success.
 
-mod backend;
+pub(crate) mod backend;
+mod redact;
+pub(crate) mod spool;
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -22,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use backend::Backend;
+use redact::redact;
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]
 pub enum HookEvent {
@@ -46,6 +49,10 @@ pub enum HookEvent {
 struct SessionState {
     turn_id: u64,
     pending_prompt: Option<String>,
+    /// Previous turn's user message, blended into the recall query so short
+    /// follow-up prompts still retrieve on-topic memories.
+    #[serde(default)]
+    last_user_message: Option<String>,
 }
 
 fn state_path(data_dir: &Path, session_id: &str) -> PathBuf {
@@ -109,14 +116,25 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
             if prompt.is_empty() {
                 return Ok(());
             }
+            let prompt = redact(&prompt);
 
             // Stash the prompt so the Stop hook can store the complete turn.
             let mut state = load_state(data_dir, &session_id);
             state.pending_prompt = Some(prompt.chars().take(8_000).collect());
             save_state(data_dir, &session_id, &state);
 
+            // Short follow-ups ("do it", "and tests?") retrieve nothing on
+            // their own; blend in the previous turn for topical grounding.
+            let query = match state.last_user_message.as_deref() {
+                Some(last) if prompt.chars().count() < 200 => {
+                    let last: String = last.chars().take(600).collect();
+                    format!("{prompt}\n\n[previous turn] {last}")
+                }
+                _ => prompt.clone(),
+            };
+
             let backend = Backend::resolve(data_dir, force_local).await?;
-            let ctx = backend.context(&prompt).await?;
+            let ctx = backend.context(&query).await?;
             if let Some(text) = format_context(&ctx) {
                 println!(
                     "{}",
@@ -130,13 +148,14 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
             }
         }
         HookEvent::Stop => {
-            let assistant = payload
+            let assistant: String = payload
                 .get("last_assistant_message")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .chars()
                 .take(16_000)
-                .collect::<String>();
+                .collect();
+            let assistant = redact(&assistant);
 
             let mut state = load_state(data_dir, &session_id);
             let Some(user_message) = state.pending_prompt.take() else {
@@ -146,6 +165,7 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
             // skips periodic maintenance for it.
             state.turn_id += 1;
             let turn_id = state.turn_id;
+            state.last_user_message = Some(user_message.chars().take(600).collect());
             save_state(data_dir, &session_id, &state);
 
             let project = payload
@@ -155,10 +175,27 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
                 .and_then(|n| n.to_str())
                 .map(str::to_string);
 
-            let backend = Backend::resolve(data_dir, force_local).await?;
-            backend
-                .store_turn(&user_message, &assistant, turn_id, project)
-                .await?;
+            let store = async {
+                let backend = Backend::resolve(data_dir, force_local).await?;
+                flush_spool(data_dir, &backend).await;
+                backend
+                    .store_turn(&user_message, &assistant, turn_id, project.clone())
+                    .await
+            }
+            .await;
+            if let Err(e) = store {
+                tracing::warn!(error = %e, "store_turn failed, spooling for retry");
+                spool::push(
+                    data_dir,
+                    &json!({
+                        "kind": "turn",
+                        "user_message": user_message,
+                        "assistant_response": assistant,
+                        "turn_id": turn_id,
+                        "project": project,
+                    }),
+                );
+            }
         }
         HookEvent::SessionStart => {
             let backend = Backend::resolve(data_dir, force_local).await?;
@@ -174,14 +211,26 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
             let Some(note) = summarize_tool_action(&payload) else {
                 return Ok(());
             };
+            let note = redact(&note);
             let project = payload
                 .get("cwd")
                 .and_then(|v| v.as_str())
                 .and_then(|c| Path::new(c).file_name())
                 .and_then(|n| n.to_str())
                 .map(str::to_string);
-            let backend = Backend::resolve(data_dir, force_local).await?;
-            backend.store_note(&note, project).await?;
+            let store = async {
+                let backend = Backend::resolve(data_dir, force_local).await?;
+                flush_spool(data_dir, &backend).await;
+                backend.store_note(&note, project.clone()).await
+            }
+            .await;
+            if let Err(e) = store {
+                tracing::warn!(error = %e, "store_note failed, spooling for retry");
+                spool::push(
+                    data_dir,
+                    &json!({ "kind": "note", "content": note, "project": project }),
+                );
+            }
         }
         HookEvent::PreCompact => {
             // The long session is about to lose context; make sure everything
@@ -191,6 +240,69 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
         }
     }
     Ok(())
+}
+
+/// Retry every spooled entry against the now-reachable backend. Entries that
+/// still fail (and everything after the first failure, to preserve order) go
+/// back into the spool.
+async fn flush_spool(data_dir: &Path, backend: &Backend) {
+    let entries = spool::take_all(data_dir);
+    if entries.is_empty() {
+        return;
+    }
+    let mut failed: Vec<serde_json::Value> = Vec::new();
+    let mut hit_failure = false;
+    for e in entries {
+        if hit_failure {
+            failed.push(e);
+            continue;
+        }
+        let ok = match e.get("kind").and_then(|v| v.as_str()) {
+            Some("turn") => {
+                let user = e.get("user_message").and_then(|v| v.as_str()).unwrap_or("");
+                if user.is_empty() {
+                    true // malformed, drop
+                } else {
+                    backend
+                        .store_turn(
+                            user,
+                            e.get("assistant_response")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or(""),
+                            e.get("turn_id").and_then(|v| v.as_u64()).unwrap_or(1),
+                            e.get("project").and_then(|v| v.as_str()).map(str::to_string),
+                        )
+                        .await
+                        .is_ok()
+                }
+            }
+            Some("note") => {
+                let content = e.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                if content.is_empty() {
+                    true
+                } else {
+                    backend
+                        .store_note(
+                            content,
+                            e.get("project").and_then(|v| v.as_str()).map(str::to_string),
+                        )
+                        .await
+                        .is_ok()
+                }
+            }
+            _ => true,
+        };
+        if !ok {
+            hit_failure = true;
+            failed.push(e);
+        }
+    }
+    if failed.is_empty() {
+        tracing::info!("offline spool fully flushed");
+    } else {
+        tracing::warn!(retained = failed.len(), "spool flush incomplete");
+        spool::restore(data_dir, &failed);
+    }
 }
 
 /// Bash command prefixes that only read state and are not worth remembering.

--- a/src/hook/redact.rs
+++ b/src/hook/redact.rs
@@ -1,0 +1,101 @@
+//! Secret redaction applied to everything the hooks persist or transmit.
+//!
+//! Turns and tool-action notes are captured verbatim from real coding
+//! sessions, which routinely contain API keys, tokens, and credentials.
+//! Nothing may leave the machine or land in the local store unredacted.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+static PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
+    let raw: &[(&str, &str)] = &[
+        // Private key blocks swallow everything between the markers, even
+        // when the closing marker was truncated away.
+        (
+            r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?(-----END [A-Z0-9 ]*PRIVATE KEY-----|\z)",
+            "[redacted:private-key]",
+        ),
+        (r"\bAKIA[0-9A-Z]{16}\b", "[redacted:aws-key]"),
+        (r"\bsk-[A-Za-z0-9_-]{16,}\b", "[redacted:api-key]"),
+        (
+            r"\b(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b|\bgithub_pat_[A-Za-z0-9_]{20,}\b",
+            "[redacted:github-token]",
+        ),
+        (r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b", "[redacted:slack-token]"),
+        (r"\bmdb_[A-Za-z0-9]{16,}\b", "[redacted:mentedb-key]"),
+        (
+            r"\beyJ[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b",
+            "[redacted:jwt]",
+        ),
+        // Scheme plus credential only, so the rest of a captured command
+        // line survives redaction.
+        (
+            r"(?i)\bauthorization\s*:\s*\S+(\s+\S+)?",
+            "authorization: [redacted]",
+        ),
+        (
+            r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{16,}",
+            "bearer [redacted]",
+        ),
+        // key=value / key: value assignments for secret-named keys.
+        (
+            r#"(?i)\b(api[_-]?key|access[_-]?key|secret[_-]?access[_-]?key|client[_-]?secret|secret|token|passwd|password)\b(\s*[=:]\s*)["']?[^\s"']{8,}["']?"#,
+            "${1}${2}[redacted]",
+        ),
+    ];
+    raw.iter()
+        .map(|(p, r)| (Regex::new(p).expect("valid redaction pattern"), *r))
+        .collect()
+});
+
+/// Replace anything that looks like a credential with a typed placeholder.
+pub fn redact(text: &str) -> String {
+    let mut out = std::borrow::Cow::Borrowed(text);
+    for (re, replacement) in PATTERNS.iter() {
+        if let std::borrow::Cow::Owned(replaced) = re.replace_all(&out, *replacement) {
+            out = std::borrow::Cow::Owned(replaced);
+        }
+    }
+    out.into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_provider_tokens() {
+        let text = "aws AKIAIOSFODNN7EXAMPLE openai sk-abc123def456ghi789jkl \
+                    github ghp_abcdefghijklmnopqrstuvwxyz123456 slack xox_b-not-a-token";
+        let out = redact(text);
+        assert!(out.contains("[redacted:aws-key]"));
+        assert!(out.contains("[redacted:api-key]"));
+        assert!(out.contains("[redacted:github-token]"));
+        assert!(!out.contains("AKIAIOSFODNN7EXAMPLE"));
+        assert!(!out.contains("sk-abc123def456ghi789jkl"));
+    }
+
+    #[test]
+    fn redacts_headers_and_assignments() {
+        let text = r#"curl -H "Authorization: Bearer abc123def456ghi789" and password=supersecret99 plus API_KEY: sk_live_whatever123"#;
+        let out = redact(text);
+        assert!(!out.contains("abc123def456ghi789"));
+        assert!(!out.contains("supersecret99"));
+        assert!(out.contains("password=[redacted]"));
+    }
+
+    #[test]
+    fn redacts_pem_blocks_and_jwts() {
+        let pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEow\nlines\n-----END RSA PRIVATE KEY-----";
+        assert_eq!(redact(pem), "[redacted:private-key]");
+        let jwt = "token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dQw4w9WgXcQabc123";
+        assert!(redact(jwt).contains("[redacted:jwt]"));
+    }
+
+    #[test]
+    fn leaves_normal_text_alone() {
+        let text = "Edited file: src/main.rs then ran cargo test, the tokenizer crate is fine";
+        assert_eq!(redact(text), text);
+    }
+}

--- a/src/hook/spool.rs
+++ b/src/hook/spool.rs
@@ -1,0 +1,97 @@
+//! Offline spool: turns and notes that failed to reach the backend are
+//! appended here and retried on later hook invocations, so a network outage
+//! or sleeping daemon never silently drops memory.
+
+use std::path::{Path, PathBuf};
+
+const SPOOL_FILE: &str = "spool.jsonl";
+const MAX_ENTRIES: usize = 1_000;
+
+pub fn spool_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(SPOOL_FILE)
+}
+
+/// Number of entries currently waiting for delivery.
+pub fn depth(data_dir: &Path) -> usize {
+    std::fs::read_to_string(spool_path(data_dir))
+        .map(|raw| raw.lines().filter(|l| !l.trim().is_empty()).count())
+        .unwrap_or(0)
+}
+
+/// Append an entry, dropping the oldest entries past the cap so a long
+/// outage cannot grow the spool without bound.
+pub fn push(data_dir: &Path, entry: &serde_json::Value) {
+    let path = spool_path(data_dir);
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let line = entry.to_string();
+    let mut lines: Vec<&str> = existing
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+    lines.push(&line);
+    let start = lines.len().saturating_sub(MAX_ENTRIES);
+    let mut body = lines[start..].join("\n");
+    body.push('\n');
+    std::fs::write(&path, body).ok();
+}
+
+/// Drain the spool, returning all pending entries. Failed entries must be
+/// handed back via `restore` or they are lost.
+pub fn take_all(data_dir: &Path) -> Vec<serde_json::Value> {
+    let path = spool_path(data_dir);
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    std::fs::remove_file(&path).ok();
+    raw.lines()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect()
+}
+
+pub fn restore(data_dir: &Path, entries: &[serde_json::Value]) {
+    for e in entries {
+        push(data_dir, e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn push_take_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(depth(dir.path()), 0);
+        push(dir.path(), &json!({"kind": "turn", "user_message": "a"}));
+        push(dir.path(), &json!({"kind": "note", "content": "b"}));
+        assert_eq!(depth(dir.path()), 2);
+
+        let entries = take_all(dir.path());
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["kind"], "turn");
+        assert_eq!(depth(dir.path()), 0);
+        assert!(take_all(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn restore_preserves_failed_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        push(dir.path(), &json!({"kind": "turn", "user_message": "a"}));
+        let entries = take_all(dir.path());
+        restore(dir.path(), &entries);
+        assert_eq!(depth(dir.path()), 1);
+    }
+
+    #[test]
+    fn caps_spool_size() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..(MAX_ENTRIES + 50) {
+            push(dir.path(), &json!({"kind": "note", "content": i}));
+        }
+        let entries = take_all(dir.path());
+        assert_eq!(entries.len(), MAX_ENTRIES);
+        // Oldest dropped, newest kept.
+        assert_eq!(entries.last().unwrap()["content"], MAX_ENTRIES + 49);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,11 @@ enum Commands {
     Logout,
     /// Check cloud connection status
     Status,
+    /// Diagnose the full memory pipeline (credentials, hooks, capture, spool)
+    Doctor,
+    /// Push memories from the local database up to MenteDB Cloud
+    #[cfg(feature = "local")]
+    Sync,
     /// Process a client lifecycle hook (reads JSON payload from stdin)
     Hook {
         /// Hook event to process
@@ -118,6 +123,15 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Login) => return run_login().await,
         Some(Commands::Logout) => return run_logout(),
         Some(Commands::Status) => return run_status().await,
+        Some(Commands::Doctor) => {
+            let data_dir = resolve_data_dir(&cli.data_dir);
+            return run_doctor(&data_dir).await;
+        }
+        #[cfg(feature = "local")]
+        Some(Commands::Sync) => {
+            let data_dir = resolve_data_dir(&cli.data_dir);
+            return run_sync(&data_dir).await;
+        }
         Some(Commands::Hook { event }) => {
             // Hooks print only their payload on stdout; logging goes to the
             // data directory so a noisy logger can never corrupt the output
@@ -393,6 +407,12 @@ async fn run_login() -> anyhow::Result<()> {
     let (tx, rx) = oneshot::channel::<String>();
     let tx = std::sync::Arc::new(tokio::sync::Mutex::new(Some(tx)));
 
+    // One-time nonce: the callback only accepts a token from the browser tab
+    // this login opened, so another local process or a malicious page cannot
+    // plant its own credentials.
+    let state_nonce = uuid::Uuid::new_v4().to_string();
+    let expected_state = state_nonce.clone();
+
     let cloud_url = std::env::var("MENTEDB_CLOUD_URL")
         .unwrap_or_else(|_| "https://app.mentedb.com".to_string());
 
@@ -409,15 +429,21 @@ async fn run_login() -> anyhow::Result<()> {
             axum::routing::post(move |body: axum::Json<serde_json::Value>| {
                 let tx = tx_clone.clone();
                 let origin = origin_for_post.clone();
+                let expected_state = expected_state.clone();
                 async move {
                     let api_key = body
                         .get("api_key")
                         .and_then(|v| v.as_str())
                         .unwrap_or_default()
                         .to_string();
+                    let state = body.get("state").and_then(|v| v.as_str()).unwrap_or("");
 
-                    if let Some(sender) = tx.lock().await.take() {
-                        let _ = sender.send(api_key);
+                    if state == expected_state {
+                        if let Some(sender) = tx.lock().await.take() {
+                            let _ = sender.send(api_key);
+                        }
+                    } else {
+                        eprintln!("  [warn] callback with wrong state nonce rejected");
                     }
 
                     let headers = [
@@ -466,7 +492,7 @@ async fn run_login() -> anyhow::Result<()> {
     });
 
     // Open browser
-    let url = format!("{cloud_url}/auth/device?callback_port={port}");
+    let url = format!("{cloud_url}/auth/device?callback_port={port}&state={state_nonce}");
     println!("  Opening browser: {url}");
     println!("  Waiting for authorization...\n");
 
@@ -497,13 +523,7 @@ async fn run_login() -> anyhow::Result<()> {
     });
 
     let config_path = mentedb_dir.join("cloud.json");
-    std::fs::write(&config_path, serde_json::to_string_pretty(&cloud_config)?)?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o600))?;
-    }
+    write_secret_file(&config_path, &serde_json::to_string_pretty(&cloud_config)?)?;
 
     server_handle.abort();
 
@@ -568,8 +588,7 @@ async fn run_status() -> anyhow::Result<()> {
             200 => {
                 println!("  Status: Connected");
                 println!("  Cloud URL: {api_url}");
-                let masked = format!("mdb_{}...", &token[4..12]);
-                println!("  Token: {masked}");
+                println!("  Token: {}", mask_token(token));
 
                 // Fetch account info
                 match client
@@ -646,6 +665,337 @@ fn load_cloud_credentials() -> Option<(String, String)> {
         .unwrap_or_else(|| "https://api.mentedb.com".to_string());
 
     Some((api_url, token.to_string()))
+}
+
+/// Mask a token for display without ever panicking on short values.
+fn mask_token(token: &str) -> String {
+    let prefix: String = token.chars().take(12).collect();
+    format!("{prefix}...")
+}
+
+/// Write a credentials file created with 0600 from the first byte, instead
+/// of writing world-readable and tightening afterwards.
+fn write_secret_file(path: &std::path::Path, contents: &str) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        f.write_all(contents.as_bytes())?;
+        // mode() only applies on create; correct pre-existing files too.
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, contents)?;
+    }
+    Ok(())
+}
+
+/// End-to-end pipeline diagnosis: answers "is memory actually working?"
+/// in one command.
+async fn run_doctor(data_dir: &std::path::Path) -> anyhow::Result<()> {
+    println!("\nMenteDB doctor v{}\n", env!("CARGO_PKG_VERSION"));
+    let mut problems = 0usize;
+
+    // 1. Backend credentials.
+    let creds = load_cloud_credentials();
+    match &creds {
+        Some((api_url, token)) => {
+            println!("  [ok]   Cloud credentials: {} ({})", mask_token(token), api_url);
+            let client = reqwest::Client::new();
+            match client
+                .get(format!("{api_url}/api/me"))
+                .header("Authorization", format!("Bearer {token}"))
+                .timeout(std::time::Duration::from_secs(10))
+                .send()
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    let me: serde_json::Value = resp.json().await.unwrap_or_default();
+                    let email = me.get("email").and_then(|v| v.as_str()).unwrap_or("?");
+                    let plan = me.get("plan").and_then(|v| v.as_str()).unwrap_or("?");
+                    println!("  [ok]   Cloud reachable, account {email} (plan: {plan})");
+                }
+                Ok(resp) if resp.status().as_u16() == 401 || resp.status().as_u16() == 403 => {
+                    problems += 1;
+                    println!("  [FAIL] Token revoked or expired. Run `mentedb-mcp login`.");
+                }
+                Ok(resp) => {
+                    problems += 1;
+                    println!("  [warn] Cloud returned HTTP {}", resp.status());
+                }
+                Err(e) => {
+                    problems += 1;
+                    println!("  [FAIL] Cloud unreachable: {e}");
+                }
+            }
+        }
+        None => {
+            println!("  [info] Not logged in: hooks use the local daemon backend.");
+            #[cfg(not(feature = "local"))]
+            {
+                problems += 1;
+                println!("  [FAIL] This build has no local mode. Run `mentedb-mcp login`.");
+            }
+        }
+    }
+
+    // 2. Claude Code hooks registered.
+    let home = home_dir().unwrap_or_else(|| "~".to_string());
+    let settings_path = std::path::PathBuf::from(&home).join(".claude/settings.json");
+    match std::fs::read_to_string(&settings_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+    {
+        Some(settings) => {
+            let expected = [
+                "UserPromptSubmit",
+                "Stop",
+                "SessionStart",
+                "PostToolUse",
+                "PreCompact",
+            ];
+            let mut missing = Vec::new();
+            for event in expected {
+                let present = settings["hooks"][event]
+                    .as_array()
+                    .is_some_and(|groups| {
+                        groups.iter().any(|g| {
+                            g["hooks"].as_array().is_some_and(|hs| {
+                                hs.iter().any(|h| {
+                                    h["command"]
+                                        .as_str()
+                                        .is_some_and(|c| c.contains("mentedb-mcp"))
+                                })
+                            })
+                        })
+                    });
+                if !present {
+                    missing.push(event);
+                }
+            }
+            if missing.is_empty() {
+                println!("  [ok]   Claude Code hooks: all 5 registered");
+            } else {
+                problems += 1;
+                println!(
+                    "  [FAIL] Claude Code hooks missing: {}. Run `npx mentedb-mcp@latest setup claude-code`.",
+                    missing.join(", ")
+                );
+            }
+        }
+        None => {
+            problems += 1;
+            println!(
+                "  [warn] No Claude Code settings at {}. Run `npx mentedb-mcp@latest setup claude-code`.",
+                settings_path.display()
+            );
+        }
+    }
+
+    // 3. Recent capture activity.
+    let sessions_dir = data_dir.join("hook_sessions");
+    let newest = std::fs::read_dir(&sessions_dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| e.metadata().ok().and_then(|m| m.modified().ok()))
+        .max();
+    match newest {
+        Some(t) => {
+            let ago = t.elapsed().map(|d| d.as_secs()).unwrap_or(0);
+            let human = if ago < 120 {
+                format!("{ago}s ago")
+            } else if ago < 7_200 {
+                format!("{}m ago", ago / 60)
+            } else {
+                format!("{}h ago", ago / 3_600)
+            };
+            println!("  [ok]   Last hook activity: {human}");
+        }
+        None => {
+            println!(
+                "  [info] No hook activity yet. Hooks fire in sessions started after setup; start a new Claude Code session."
+            );
+        }
+    }
+
+    // 4. Offline spool depth.
+    let depth = hook::spool::depth(data_dir);
+    if depth == 0 {
+        println!("  [ok]   Offline spool: empty");
+    } else {
+        println!("  [warn] Offline spool: {depth} undelivered entries (retried on next turn)");
+    }
+
+    // 5. Recent hook errors from the log.
+    let today = chrono_free_today();
+    let log_path = data_dir.join(format!("mentedb-hook.log.{today}"));
+    let warns: Vec<String> = std::fs::read_to_string(&log_path)
+        .map(|raw| {
+            raw.lines()
+                .filter(|l| l.contains("WARN") || l.contains("ERROR"))
+                .rev()
+                .take(3)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    if warns.is_empty() {
+        println!("  [ok]   Hook log: no recent errors");
+    } else {
+        println!("  [warn] Recent hook errors ({}):", log_path.display());
+        for w in warns.iter().rev() {
+            let trimmed: String = w.chars().take(160).collect();
+            println!("           {trimmed}");
+        }
+    }
+
+    // 6. Local daemon, when that is the active backend.
+    #[cfg(feature = "local")]
+    if creds.is_none() {
+        match crate::daemon::read_info(data_dir) {
+            Some(info) => {
+                let url = format!("http://127.0.0.1:{}/health", info.port);
+                let healthy = reqwest::Client::new()
+                    .get(&url)
+                    .timeout(std::time::Duration::from_secs(2))
+                    .send()
+                    .await
+                    .map(|r| r.status().is_success())
+                    .unwrap_or(false);
+                if healthy {
+                    println!("  [ok]   Local daemon: running on port {}", info.port);
+                } else {
+                    println!("  [info] Local daemon: not running (auto-starts on first hook)");
+                }
+            }
+            None => println!("  [info] Local daemon: not started yet (auto-starts on first hook)"),
+        }
+    }
+
+    println!();
+    if problems == 0 {
+        println!("  Everything looks healthy.");
+    } else {
+        println!("  {problems} problem(s) found. Fix the [FAIL] items above.");
+    }
+    Ok(())
+}
+
+/// Today's UTC date as YYYY-MM-DD without pulling in a date crate: the
+/// tracing_appender daily logs use this suffix.
+fn chrono_free_today() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let days = secs / 86_400;
+    // Civil-from-days (Howard Hinnant's algorithm), valid for the era we run in.
+    let z = days as i64 + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+/// Push every memory in the local database up to MenteDB Cloud, so a user
+/// who started local and later logs in keeps their history. Idempotent via
+/// a ledger of already-pushed memory IDs.
+#[cfg(feature = "local")]
+async fn run_sync(data_dir: &std::path::Path) -> anyhow::Result<()> {
+    let Some((api_url, token)) = load_cloud_credentials() else {
+        anyhow::bail!("Not logged in. Run `mentedb-mcp login` first, then `mentedb-mcp sync`.");
+    };
+
+    println!("\nSyncing local memories to MenteDB Cloud...\n");
+
+    let daemon = hook::backend::LocalDaemonClient::connect_or_spawn(data_dir).await?;
+    let export = daemon.post("/v1/export", serde_json::json!({})).await?;
+    let memories = export
+        .get("memories")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    if memories.is_empty() {
+        println!("  Local database has no memories to sync.");
+        return Ok(());
+    }
+
+    let ledger_path = data_dir.join("sync_state.json");
+    let mut pushed: std::collections::HashSet<String> = std::fs::read_to_string(&ledger_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default();
+
+    let client = cloud_client::CloudClient::new(api_url, token);
+    let total = memories.len();
+    let mut sent = 0usize;
+    let mut skipped = 0usize;
+    let mut failed = 0usize;
+
+    for m in &memories {
+        let id = m.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let content = m.get("content").and_then(|v| v.as_str()).unwrap_or("");
+        if id.is_empty() || content.is_empty() || pushed.contains(&id) {
+            skipped += 1;
+            continue;
+        }
+        let mut tags: Vec<String> = m
+            .get("tags")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| t.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+        tags.push("synced-from-local".to_string());
+
+        let args = serde_json::json!({
+            "content": content,
+            "memory_type": m.get("memory_type").and_then(|v| v.as_str()).unwrap_or("episodic"),
+            "tags": tags,
+        });
+        match client.call_tool("store_memory", args).await {
+            Ok(_) => {
+                pushed.insert(id);
+                sent += 1;
+                if sent.is_multiple_of(25) {
+                    println!("  {sent}/{total} pushed...");
+                    std::fs::write(&ledger_path, serde_json::to_string(&pushed)?).ok();
+                }
+            }
+            Err(e) => {
+                failed += 1;
+                if failed <= 3 {
+                    eprintln!("  [warn] failed to push {id}: {e}");
+                }
+            }
+        }
+    }
+    std::fs::write(&ledger_path, serde_json::to_string(&pushed)?)?;
+
+    println!("\n  Done: {sent} pushed, {skipped} already synced or empty, {failed} failed.");
+    if failed > 0 {
+        println!("  Re-run `mentedb-mcp sync` to retry failures.");
+    }
+    Ok(())
 }
 
 fn run_setup(client: SetupClient, force: bool) -> anyhow::Result<()> {


### PR DESCRIPTION
Closes the gaps from the cognitive engine evaluation, all in one PR.

Capture quality and safety:
- Secret redaction on everything hooks persist or transmit (AWS keys, API keys, GitHub and Slack tokens, JWTs, bearer and authorization credentials, key=value assignments, private key blocks). Applied to prompts at stash time, assistant messages at Stop, and tool action notes. Verified end to end against the live cloud API.
- Recall query blends the previous turn into short follow-up prompts so "do it" and "and tests?" still retrieve on-topic memories.
- session_context prefers the new get_session_context gateway tool (deterministic scope:always injection) and falls back to search on older gateways. Also fixes the same memories/results key mismatch that broke cloud context injection in 0.5.8.

Durability:
- Offline spool: turns and notes that fail to reach the backend (network outage, cold daemon) are spooled to disk and retried on later hook invocations instead of silently dropping. Capped at 1000 entries, order preserving.
- mentedb-mcp sync pushes the local database to MenteDB Cloud through a new daemon /v1/export endpoint, with an idempotency ledger, so local-first users keep their history when they log in.

Operability:
- mentedb-mcp doctor diagnoses the whole pipeline in one command: credentials, cloud reachability and account, hook registration in Claude Code settings, last capture activity, spool depth, recent hook errors, local daemon health.

Security fixes:
- status no longer panics on short tokens (unchecked slice).
- Login callback requires a one-time state nonce, so another local process or malicious page cannot plant attacker credentials. Requires the dashboard device-auth page to echo the state param (platform PR ships first).
- cloud.json and daemon.json are created 0600 from the first byte instead of write-then-chmod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)