### PR TITLE
feat: default setup and update to claude-code

### DIFF
--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -270,7 +270,9 @@ async fn flush_spool(data_dir: &Path, backend: &Backend) {
                                 .and_then(|v| v.as_str())
                                 .unwrap_or(""),
                             e.get("turn_id").and_then(|v| v.as_u64()).unwrap_or(1),
-                            e.get("project").and_then(|v| v.as_str()).map(str::to_string),
+                            e.get("project")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string),
                         )
                         .await
                         .is_ok()
@@ -284,7 +286,9 @@ async fn flush_spool(data_dir: &Path, backend: &Backend) {
                     backend
                         .store_note(
                             content,
-                            e.get("project").and_then(|v| v.as_str()).map(str::to_string),
+                            e.get("project")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string),
                         )
                         .await
                         .is_ok()

--- a/src/hook/redact.rs
+++ b/src/hook/redact.rs
@@ -22,7 +22,10 @@ static PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
             r"\b(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b|\bgithub_pat_[A-Za-z0-9_]{20,}\b",
             "[redacted:github-token]",
         ),
-        (r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b", "[redacted:slack-token]"),
+        (
+            r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b",
+            "[redacted:slack-token]",
+        ),
         (r"\bmdb_[A-Za-z0-9]{16,}\b", "[redacted:mentedb-key]"),
         (
             r"\beyJ[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b",

--- a/src/hook/spool.rs
+++ b/src/hook/spool.rs
@@ -24,10 +24,7 @@ pub fn push(data_dir: &Path, entry: &serde_json::Value) {
     let path = spool_path(data_dir);
     let existing = std::fs::read_to_string(&path).unwrap_or_default();
     let line = entry.to_string();
-    let mut lines: Vec<&str> = existing
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .collect();
+    let mut lines: Vec<&str> = existing.lines().filter(|l| !l.trim().is_empty()).collect();
     lines.push(&line);
     let start = lines.len().saturating_sub(MAX_ENTRIES);
     let mut body = lines[start..].join("\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -708,7 +708,11 @@ async fn run_doctor(data_dir: &std::path::Path) -> anyhow::Result<()> {
     let creds = load_cloud_credentials();
     match &creds {
         Some((api_url, token)) => {
-            println!("  [ok]   Cloud credentials: {} ({})", mask_token(token), api_url);
+            println!(
+                "  [ok]   Cloud credentials: {} ({})",
+                mask_token(token),
+                api_url
+            );
             let client = reqwest::Client::new();
             match client
                 .get(format!("{api_url}/api/me"))
@@ -764,19 +768,17 @@ async fn run_doctor(data_dir: &std::path::Path) -> anyhow::Result<()> {
             ];
             let mut missing = Vec::new();
             for event in expected {
-                let present = settings["hooks"][event]
-                    .as_array()
-                    .is_some_and(|groups| {
-                        groups.iter().any(|g| {
-                            g["hooks"].as_array().is_some_and(|hs| {
-                                hs.iter().any(|h| {
-                                    h["command"]
-                                        .as_str()
-                                        .is_some_and(|c| c.contains("mentedb-mcp"))
-                                })
+                let present = settings["hooks"][event].as_array().is_some_and(|groups| {
+                    groups.iter().any(|g| {
+                        g["hooks"].as_array().is_some_and(|hs| {
+                            hs.iter().any(|h| {
+                                h["command"]
+                                    .as_str()
+                                    .is_some_and(|c| c.contains("mentedb-mcp"))
                             })
                         })
-                    });
+                    })
+                });
                 if !present {
                     missing.push(event);
                 }
@@ -950,7 +952,11 @@ async fn run_sync(data_dir: &std::path::Path) -> anyhow::Result<()> {
     let mut failed = 0usize;
 
     for m in &memories {
-        let id = m.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let id = m
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
         let content = m.get("content").and_then(|v| v.as_str()).unwrap_or("");
         if id.is_empty() || content.is_empty() || pushed.contains(&id) {
             skipped += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,13 +73,13 @@ enum Commands {
     /// Auto-configure MenteDB for your MCP client (Copilot CLI, Claude, Cursor, etc.)
     Setup {
         /// Target client
-        #[arg(value_enum, default_value = "copilot")]
+        #[arg(value_enum, default_value = "claude-code")]
         client: SetupClient,
     },
     /// Update MCP config and agent instructions (overwrites existing entries)
     Update {
         /// Target client
-        #[arg(value_enum, default_value = "copilot")]
+        #[arg(value_enum, default_value = "claude-code")]
         client: SetupClient,
     },
     /// Authenticate with MenteDB Cloud


### PR DESCRIPTION
Claude Code hooks are the flagship integration; bare `npx mentedb-mcp@latest setup` now configures it by default instead of Copilot. Copilot, Cursor, and Claude Desktop remain available as explicit arguments. Matches the dashboard and docs, which now lead with Claude everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)