### PR TITLE
feat: native engine injection attention with outcome reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20aaa70bcf3ed44310a7cea69059c3a72eedef6cec4cffd10d57dbeeb3eb6826"
+checksum = "77ff2f7a2eab1c25cd527448bf494cddbb8557db980a6ada8e142e3c29947efc"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95377e6f3eb29cc82bcba3a53951d493ecc4275a554acaa0362cbd3686c70fc0"
+checksum = "f5b23e031a4f45e1807261a95d1074df10958f0718b3561c6f10d05bfdc19af6"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1718,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978f95128f99e6b5fda6f963c04c50ad3cf0a94d0376d39d2f58ea2920542eb4"
+checksum = "8d0a8d6e0d6a4d1c7c79803904ffc68a18926ada1018991b15cb5589d3e2b85c"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1578e6569a93e8251c22b84cf8641ac47069e08d769fae76be826687bd1eeb"
+checksum = "af782435b832825c6e17e11391f938150eb8dc51267e75ce93bdca0daebbe85a"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1745,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac08810da0f7c01bc36b71d085e25eedaba2a9f35be19d8b441f02d07051bf5"
+checksum = "a8daa232db8c364f69b31124f1ff24338dc343b1b5a677c572639190febf228d"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1762,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8d640baaf86f546ee8bfbba93dbf3eabdaf5ee606ccda431f6249f1cb45867"
+checksum = "69320251815042de9d5bfec11d28a03cae21af83cc40f34c06a249a47b64495a"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1781,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411e39ed361f924e2c3015ce5473a6e0ec17cc1241efcf43baeded266436516"
+checksum = "efd2f687ca9151d76fee56129aa436d6b1f4e317cd54d9ab1c4f854cbe5e3300"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1799,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8dab62f20d2452a3e01b5ae212d2fffdd1182b08e762ad2bcffedad4d2e03b"
+checksum = "fd4b34b2b8a5cd5d5f0de1418a9761b0fcd07d743f00a3593a55837aea21e837"
 dependencies = [
  "ahash",
  "bincode",
@@ -1816,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e829e3258fd927880115e63f61a92a65e9e3a6c12ca461899dbba5e9f2e8dec3"
+checksum = "319b202f6a84640a230f5606a8edd8d8252c138d4db31f86657af43fa08bdbae"
 dependencies = [
  "ahash",
  "bincode",
@@ -1866,9 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5ca8ad455e503988e3f4eecde2410258be6f2b021bbe7ef758b5e4382aad5c"
+checksum = "e5972a84c17eb4f7fe899b248d2868c3a3727ec9890655b59b538eebc670e196"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1879,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1551c284aa6ae3e7a848dbee044368253983daab6f542f30c352f93cf0ba668"
+checksum = "9bf11824a3bbeac1cdbdec357e28f9e7021e5ace0f5d9ad56b840f87e12beec9"
 dependencies = [
  "ahash",
  "bincode",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -91,6 +91,8 @@ struct TurnRequest {
     turn_id: u64,
     #[serde(default)]
     project_context: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
 }
 
 async fn turn(
@@ -110,6 +112,7 @@ async fn turn(
             turn_id: req.turn_id,
             project_context: req.project_context,
             agent_id: None,
+            session_id: req.session_id,
         }))
         .await
         .map_err(|e| {
@@ -181,6 +184,111 @@ async fn flush(
         return Err(StatusCode::INTERNAL_SERVER_ERROR);
     }
     Ok(Json(json!({ "ok": true })))
+}
+
+#[derive(Deserialize)]
+struct InjectionContextRequest {
+    query: String,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    exclude_ids: Vec<String>,
+    #[serde(default)]
+    max_items: Option<usize>,
+    #[serde(default)]
+    max_episodic: Option<usize>,
+}
+
+/// Injection-ready context through the engine's attention policy.
+async fn injection_context(
+    State(state): State<DaemonState>,
+    headers: HeaderMap,
+    Json(req): Json<InjectionContextRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !authorized(&state, &headers) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    let db = state.server.db_ref();
+    let embedding = db.embed_text(&req.query).ok().flatten().unwrap_or_default();
+    let exclude: Vec<mentedb::prelude::MemoryId> = req
+        .exclude_ids
+        .iter()
+        .filter_map(|s| uuid::Uuid::parse_str(s).ok())
+        .map(mentedb::prelude::MemoryId)
+        .collect();
+
+    let query = mentedb::injection::InjectionQuery {
+        embedding: &embedding,
+        query_text: Some(&req.query),
+        session_id: req.session_id.as_deref(),
+        exclude_ids: &exclude,
+        max_items: req.max_items.unwrap_or(6).min(20),
+        max_episodic: req.max_episodic.unwrap_or(2).min(10),
+    };
+    let selected = db.recall_for_injection(&query).map_err(|e| {
+        tracing::error!(error = %e, "injection recall failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let memories: Vec<serde_json::Value> = selected
+        .iter()
+        .map(|c| {
+            json!({
+                "id": c.node.id.to_string(),
+                "content": c.node.content,
+                "memory_type": memory_type_str(&c.node.memory_type),
+                "tags": c.node.tags,
+                "created_at": c.node.created_at.to_string(),
+                "score": c.score,
+                "reason": match c.reason {
+                    mentedb::injection::SelectionReason::Pinned => "pinned",
+                    mentedb::injection::SelectionReason::Relevant => "relevant",
+                },
+            })
+        })
+        .collect();
+    Ok(Json(json!({ "memories": memories, "pain": [] })))
+}
+
+#[derive(Deserialize)]
+struct InjectionOutcomeRequest {
+    #[serde(default)]
+    shown_ids: Vec<String>,
+    #[serde(default)]
+    assistant_text: String,
+}
+
+/// Close the attention loop: usage detection against the reply.
+async fn injection_outcome(
+    State(state): State<DaemonState>,
+    headers: HeaderMap,
+    Json(req): Json<InjectionOutcomeRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !authorized(&state, &headers) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    let db = state.server.db_ref();
+    let shown: Vec<mentedb::prelude::MemoryId> = req
+        .shown_ids
+        .iter()
+        .filter_map(|s| uuid::Uuid::parse_str(s).ok())
+        .map(mentedb::prelude::MemoryId)
+        .collect();
+    let reply_embedding = if req.assistant_text.is_empty() {
+        None
+    } else {
+        db.embed_text(&req.assistant_text).ok().flatten()
+    };
+    let (shown_updated, used) = db
+        .record_injection_outcome(&shown, reply_embedding.as_deref())
+        .map_err(|e| {
+            tracing::error!(error = %e, "injection outcome failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    if let Err(e) = db.flush() {
+        tracing::warn!(error = %e, "post-outcome flush failed");
+    }
+    Ok(Json(json!({ "shown": shown_updated, "used": used })))
 }
 
 /// Dump every memory for `mentedb-mcp sync` (local to cloud migration).
@@ -271,6 +379,8 @@ pub async fn run(config: ServerConfig) -> anyhow::Result<()> {
         .route("/v1/flush", post(flush))
         .route("/v1/session-context", post(session_context))
         .route("/v1/export", post(export))
+        .route("/v1/injection-context", post(injection_context))
+        .route("/v1/injection-outcome", post(injection_outcome))
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;

--- a/src/hook/backend.rs
+++ b/src/hook/backend.rs
@@ -71,6 +71,83 @@ impl Backend {
         }
     }
 
+    /// Injection-ready context through the engine's native attention policy
+    /// (session exclusion, ledger, knee, MMR, quotas, pinned bypass).
+    /// Returns None when the backend predates the API, so the caller can
+    /// fall back to the local heuristic filter.
+    pub async fn injection_context(
+        &self,
+        query: &str,
+        session_id: &str,
+        exclude_ids: &[String],
+    ) -> Option<serde_json::Value> {
+        match self {
+            Backend::Cloud(client) => {
+                let resp = client
+                    .call_tool(
+                        "get_injection_context",
+                        json!({
+                            "query": query,
+                            "session_id": session_id,
+                            "exclude_ids": exclude_ids,
+                        }),
+                    )
+                    .await
+                    .ok()?;
+                let text = resp.content.first().map(|c| c.text.clone())?;
+                if resp.is_error {
+                    // Older gateway: unknown tool comes back as a tool error.
+                    return None;
+                }
+                let parsed: serde_json::Value = serde_json::from_str(&text).ok()?;
+                parsed.get("memories")?.as_array()?;
+                Some(json!({
+                    "memories": parsed["memories"],
+                    "pain": parsed.get("pain").cloned().unwrap_or_else(|| json!([])),
+                }))
+            }
+            #[cfg(feature = "local")]
+            Backend::Local(client) => client
+                .post(
+                    "/v1/injection-context",
+                    json!({
+                        "query": query,
+                        "session_id": session_id,
+                        "exclude_ids": exclude_ids,
+                    }),
+                )
+                .await
+                .ok(),
+        }
+    }
+
+    /// Close the attention loop: report which injected memories the reply
+    /// drew on. Best-effort; older backends simply ignore it.
+    pub async fn record_injection_outcome(&self, shown_ids: &[String], assistant_text: &str) {
+        if shown_ids.is_empty() {
+            return;
+        }
+        match self {
+            Backend::Cloud(client) => {
+                let _ = client
+                    .call_tool(
+                        "record_injection_outcome",
+                        json!({ "shown_ids": shown_ids, "assistant_text": assistant_text }),
+                    )
+                    .await;
+            }
+            #[cfg(feature = "local")]
+            Backend::Local(client) => {
+                let _ = client
+                    .post(
+                        "/v1/injection-outcome",
+                        json!({ "shown_ids": shown_ids, "assistant_text": assistant_text }),
+                    )
+                    .await;
+            }
+        }
+    }
+
     /// Store a completed turn through the full process_turn pipeline.
     pub async fn store_turn(
         &self,
@@ -78,12 +155,14 @@ impl Backend {
         assistant_response: &str,
         turn_id: u64,
         project_context: Option<String>,
+        session_id: &str,
     ) -> anyhow::Result<()> {
         let args = json!({
             "user_message": user_message,
             "assistant_response": assistant_response,
             "turn_id": turn_id,
             "project_context": project_context,
+            "session_id": session_id,
         });
         match self {
             Backend::Cloud(client) => {

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -57,6 +57,10 @@ struct SessionState {
     /// injector, so the same fact is never re-told turn after turn.
     #[serde(default)]
     injected: Vec<String>,
+    /// Memory IDs injected on the most recent prompt, awaiting outcome
+    /// reporting when the turn's reply arrives at Stop.
+    #[serde(default)]
+    last_injected: Vec<String>,
     /// Last stored action note, to collapse consecutive duplicates
     /// (iterating on one file should not produce N identical memories).
     #[serde(default)]
@@ -142,32 +146,57 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
             };
 
             let backend = Backend::resolve(data_dir, force_local).await?;
-            let ctx = match backend.context(&query).await {
-                Ok(c) => {
+
+            // Native path: the engine owns selection (session exclusion,
+            // ledger, knee, MMR, quotas, pinned bypass). Fallback: raw
+            // recall shaped by the local heuristic filter, for backends
+            // that predate the injection API.
+            let native = backend
+                .injection_context(&query, &session_id, &state.injected)
+                .await;
+            let (ctx, injected_ids) = match native {
+                Some(ctx) => {
                     record_auth_state(data_dir, None);
-                    Some(c)
+                    let ids: Vec<String> = ctx["memories"]
+                        .as_array()
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|m| m.get("id").and_then(|v| v.as_str()))
+                                .map(str::to_string)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    (Some(ctx), ids)
                 }
-                Err(e) => {
-                    record_auth_state(data_dir, Some(&e));
-                    tracing::warn!(error = %e, "context recall failed");
-                    None
-                }
+                None => match backend.context(&query).await {
+                    Ok(c) => {
+                        record_auth_state(data_dir, None);
+                        let (filtered, ids) =
+                            filter_for_injection(&c, &state.injected, now_micros());
+                        (Some(filtered), ids)
+                    }
+                    Err(e) => {
+                        record_auth_state(data_dir, Some(&e));
+                        tracing::warn!(error = %e, "context recall failed");
+                        (None, Vec::new())
+                    }
+                },
             };
+
             let mut text = String::new();
             if let Some(ctx) = &ctx {
-                let (filtered, injected_ids) =
-                    filter_for_injection(ctx, &state.injected, now_micros());
                 if !injected_ids.is_empty() {
                     let mut state = load_state(data_dir, &session_id);
-                    state.injected.extend(injected_ids);
+                    state.injected.extend(injected_ids.clone());
                     // Bounded ledger: ancient sessions can re-surface things.
                     let excess = state.injected.len().saturating_sub(300);
                     if excess > 0 {
                         state.injected.drain(..excess);
                     }
+                    state.last_injected = injected_ids;
                     save_state(data_dir, &session_id, &state);
                 }
-                text = format_context(&filtered).unwrap_or_default();
+                text = format_context(ctx).unwrap_or_default();
             }
             if let Some(notice) = auth_notice(data_dir) {
                 text = if text.is_empty() {
@@ -219,11 +248,25 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
                 .and_then(|n| n.to_str())
                 .map(str::to_string);
 
+            let outcome_ids = std::mem::take(&mut state.last_injected);
+            save_state(data_dir, &session_id, &state);
+
             let store = async {
                 let backend = Backend::resolve(data_dir, force_local).await?;
                 flush_spool(data_dir, &backend).await;
+                // Attention learns: report which injected memories this
+                // reply actually drew on before storing the turn.
                 backend
-                    .store_turn(&user_message, &assistant, turn_id, project.clone())
+                    .record_injection_outcome(&outcome_ids, &assistant)
+                    .await;
+                backend
+                    .store_turn(
+                        &user_message,
+                        &assistant,
+                        turn_id,
+                        project.clone(),
+                        &session_id,
+                    )
                     .await
             }
             .await;
@@ -238,6 +281,7 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
                         "assistant_response": assistant,
                         "turn_id": turn_id,
                         "project": project,
+                        "session_id": session_id,
                     }),
                 );
             }
@@ -384,6 +428,7 @@ async fn flush_spool(data_dir: &Path, backend: &Backend) {
                             e.get("project")
                                 .and_then(|v| v.as_str())
                                 .map(str::to_string),
+                            e.get("session_id").and_then(|v| v.as_str()).unwrap_or(""),
                         )
                         .await
                         .is_ok()

--- a/src/tools/process_turn.rs
+++ b/src/tools/process_turn.rs
@@ -112,6 +112,7 @@ impl MenteDbServer {
             turn_id: req.turn_id,
             project_context: req.project_context.clone(),
             agent_id: Some(agent_id),
+            session_id: req.session_id.clone(),
         };
 
         // Core pipeline: single call handles embedding, context retrieval,

--- a/src/tools/types.rs
+++ b/src/tools/types.rs
@@ -161,6 +161,10 @@ pub struct ProcessTurnRequest {
     pub project_context: Option<String>,
     #[schemars(description = "Optional agent UUID. Defaults to nil UUID if not provided.")]
     pub agent_id: Option<String>,
+    #[schemars(
+        description = "Originating session ID. Stored turns are tagged with it so injection recall can exclude them for that session."
+    )]
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]


### PR DESCRIPTION
Engine 0.10.1 bump plus the client half of the injection attention rewire. The hook-side heuristic filter is now fallback-only.

- UserPromptSubmit prefers the native path: get_injection_context (cloud) or /v1/injection-context (daemon), passing the session ID and the working-memory ledger as exclude_ids so selection happens inside the engine (session provenance replaces the 12 hour freshness heuristic, relevance knee replaces the fixed floor, embedding MMR replaces word Jaccard, quotas and pinned bypass built in). Backends that predate the API fall back to the local filter unchanged.
- Stop reports outcomes: the memory IDs injected on the prompt are handed to record_injection_outcome with the assistant reply, so used memories reinforce and chronically ignored ones demote. Attention that learns.
- Turns carry session provenance end to end: hook to daemon /v1/turn and cloud process_turn session_id, tagged by the engine on the stored episodic memory.
- Spooled turns preserve their session ID across offline gaps.

The e2e suite exercises the native path: same-session echo suppression now proven via engine session exclusion rather than the client clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)