### PR TITLE
feat: update advice surfaced in the assistant's context

### DIFF
--- a/src/cloud_client.rs
+++ b/src/cloud_client.rs
@@ -55,6 +55,8 @@ impl CloudClient {
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.token))
             .header("Content-Type", "application/json")
+            // Lets the platform advise when this client is outdated.
+            .header("x-mentedb-client", env!("CARGO_PKG_VERSION"))
             .json(&ToolCallRequest {
                 name: name.to_string(),
                 arguments,

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -757,12 +757,22 @@ fn format_session_context(ctx: &serde_json::Value) -> Option<String> {
         .and_then(|v| v.as_array())
         .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
         .unwrap_or_default();
+    let update_msg = ctx
+        .get("client_update")
+        .and_then(|u| u.get("message"))
+        .and_then(|v| v.as_str());
 
-    if profile.is_empty() && always.is_empty() {
+    if profile.is_empty() && always.is_empty() && update_msg.is_none() {
         return None;
     }
 
-    let mut text = String::from("MenteDB persistent memory for this user:\n");
+    let mut text = String::new();
+    if let Some(msg) = update_msg {
+        // Surfaced inside the assistant's context so the user is told to
+        // update without ever checking the dashboard.
+        text.push_str(&format!("[MenteDB] {msg}\n\n"));
+    }
+    text.push_str("MenteDB persistent memory for this user:\n");
     if !profile.is_empty() {
         text.push_str("## User profile\n");
         text.push_str(profile);


### PR DESCRIPTION
## Summary
Users on outdated CLI versions had no way to find out. The platform now advises, and the advice shows up inside Claude.

## Changes
- Sends x-mentedb-client with the crate version on cloud calls
- When the platform reports a newer release, the session start context leads with the update instruction

## Verification
- Unit tests green; end to end verified against the platform's client_update response