### PR TITLE
feat: plan limit notice in the injected context

### DIFF
--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -737,11 +737,22 @@ fn format_context(ctx: &serde_json::Value) -> Option<String> {
         }
     }
 
-    if out.is_empty() && warnings.is_empty() {
+    // Plan limit notices ride the injection payload because it reaches the
+    // assistant on every prompt; without this the limit was invisible and
+    // memory just silently stopped storing.
+    let limit_notice = ctx.get("limit_notice").and_then(|v| v.as_str());
+
+    if out.is_empty() && warnings.is_empty() && limit_notice.is_none() {
         return None;
     }
 
-    let mut text = String::from("Relevant memories from MenteDB (persistent memory):\n");
+    let mut text = String::new();
+    if let Some(notice) = limit_notice {
+        text.push_str(&format!(
+            "[MenteDB] {notice} Tell the user if they ask about memory.\n\n"
+        ));
+    }
+    text.push_str("Relevant memories from MenteDB (persistent memory):\n");
     text.push_str(&out);
     if !warnings.is_empty() {
         text.push_str(&warnings);


### PR DESCRIPTION
## Summary
When a user hits their monthly turn limit, nothing told them; the hook swallowed the error and memory silently stopped storing.

## Changes
- The injection payload's limit_notice renders at the top of the injected context, so the assistant sees the limit state on every prompt and can tell the user

## Verification
- Unit tests green; pairs with the platform's read only limit handling (v0.7.23)