### PR TITLE
feat: cloud tool parity plus README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Then authenticate:
 npx mentedb-mcp@latest login
 ```
 
+Login is optional: without it, everything runs locally (see Local mode). On a remote or SSH session the browser cannot reach the CLI callback; after you authorize, the dashboard shows a connection code to paste into the waiting terminal.
+
 That's it. Your agent now has persistent memory that works across all your sessions and devices. Replace `copilot` with `cursor` or `claude` for other editors.
 
 ### Claude Code: hooks instead of MCP (recommended)
@@ -187,8 +189,17 @@ By default, the server exposes 4 essential tools:
 |------|-------------|
 | `process_turn` | **Call every turn.** Stores conversation, retrieves context, detects contradictions, generates pain warnings. Triggers automatic enrichment when LLM is configured. Accepts `project_context` and `agent_id` for scoping. |
 | `store_memory` | Store an important fact with type, tags, and optional scope. |
+| `store_memories` | Store several memories in one batch transaction (one lock and flush, near duplicate rejection). Accepts optional `agent_id` for scoped ownership. |
 | `search_memories` | Semantic search by query, or get full content by memory UUID. Accepts `limit` (default 10, max 50) and `memory_type` filter. |
 | `forget_memory` | Delete a memory by ID. Accepts optional `reason` for audit logging. |
+
+### Multi agent isolation
+
+Pass an `agent_id` (any stable UUID per agent) to `process_turn` and `store_memories` and each agent recalls only its own memories plus shared ones (stored without an agent). Omit it and everything stays globally visible, matching single agent behavior. A coding agent and a research agent sharing one database no longer contaminate each other's context.
+
+### Plan limits
+
+Hitting a monthly limit never breaks recall: reads keep working, new turns are served read only, and the injected context carries a notice so the assistant can tell the user. Upgrading unblocks instantly.
 
 ### What `process_turn` returns
 

--- a/src/cloud_server.rs
+++ b/src/cloud_server.rs
@@ -35,6 +35,34 @@ pub struct ProcessTurnRequest {
     pub project_context: Option<String>,
     #[schemars(description = "Optional agent UUID. Defaults to nil UUID if not provided.")]
     pub agent_id: Option<String>,
+    #[schemars(
+        description = "Originating session id; stored turns are tagged with it so injection recall can exclude the requesting session's own turns."
+    )]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct StoreMemoryItem {
+    #[schemars(description = "The text content of the memory to store")]
+    pub content: String,
+    #[schemars(
+        description = "Memory type: episodic, semantic, procedural, anti_pattern, reasoning, or correction"
+    )]
+    pub memory_type: String,
+    #[schemars(description = "Optional tags for categorization")]
+    pub tags: Option<Vec<String>>,
+    #[schemars(description = "Memory scope: 'contextual' (default) or 'always'")]
+    pub scope: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct StoreMemoriesRequest {
+    #[schemars(description = "Memories to store in one batch transaction (at most 100)")]
+    pub memories: Vec<StoreMemoryItem>,
+    #[schemars(
+        description = "Optional agent UUID; stored memories belong to this agent for scoped retrieval"
+    )]
+    pub agent_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -129,6 +157,20 @@ impl CloudMenteDbServer {
     ) -> Result<CallToolResult, McpError> {
         self.proxy_tool(
             "process_turn",
+            serde_json::to_value(&req).unwrap_or_default(),
+        )
+        .await
+    }
+
+    #[rmcp::tool(
+        description = "Store several memories in one batch transaction: one lock and flush for the whole set, with near duplicate rejection. Prefer this over repeated store_memory calls."
+    )]
+    async fn store_memories(
+        &self,
+        Parameters(req): Parameters<StoreMemoriesRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        self.proxy_tool(
+            "store_memories",
             serde_json::to_value(&req).unwrap_or_default(),
         )
         .await


### PR DESCRIPTION
## Summary
The cloud MCP server lagged the platform: no batch store tool and no session provenance on turns, and the README predated this weekend's releases.

## Changes
- store_memories tool proxied for MCP clients (batch transaction, near duplicate rejection, optional agent_id ownership)
- process_turn accepts session_id so injection recall can exclude the requesting session's own turns
- README: login marked optional with the SSH connection code path, store_memories in the tool table, multi agent isolation and plan limit behavior documented

## Verification
- Gates green with pipefail