### PR TITLE
fix: no raw LLM provider errors leaked to users

### DIFF
--- a/src/tools/ingest.rs
+++ b/src/tools/ingest.rs
@@ -80,12 +80,10 @@ impl MenteDbServer {
                     self.embedding_provider.as_ref(),
                 )
                 .await
-                .map_err(|e| McpError::internal_error(format!("Extraction failed: {e}"), None))?
+                .map_err(|e| McpError::internal_error(friendly_extraction_error(&e), None))?
         } else {
-            let http_provider =
-                mentedb_extraction::HttpExtractionProvider::new(config).map_err(|e| {
-                    McpError::internal_error(format!("Provider init failed: {e}"), None)
-                })?;
+            let http_provider = mentedb_extraction::HttpExtractionProvider::new(config)
+                .map_err(|e| McpError::internal_error(friendly_extraction_error(&e), None))?;
             let pipeline = ExtractionPipeline::new(http_provider, ExtractionConfig::default());
             pipeline
                 .process(
@@ -94,7 +92,7 @@ impl MenteDbServer {
                     self.embedding_provider.as_ref(),
                 )
                 .await
-                .map_err(|e| McpError::internal_error(format!("Extraction failed: {e}"), None))?
+                .map_err(|e| McpError::internal_error(friendly_extraction_error(&e), None))?
         };
 
         let db = &*self.db;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -255,6 +255,31 @@ pub(crate) fn error_result(msg: &str) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::error(vec![Content::text(msg.to_string())]))
 }
 
+/// Translate a low level extraction error into a clear, actionable message
+/// instead of leaking a raw provider validation string (e.g. "prompt is
+/// required when stop is not true"). Enrichment degrades gracefully, so the
+/// message always reassures that stored memories are safe.
+pub(crate) fn friendly_extraction_error(e: &mentedb_extraction::ExtractionError) -> String {
+    use mentedb_extraction::ExtractionError as E;
+    let cause = match e {
+        E::AuthError(_) => {
+            "the LLM provider rejected the credentials (check llm_api_key or MENTEDB_LLM_API_KEY)"
+        }
+        E::ModelNotFound(_) => "the configured model was not found (check llm_model)",
+        E::ConfigError(_) => "the LLM provider is misconfigured (check llm_provider and llm_model)",
+        E::RateLimitExceeded { .. } => {
+            "the LLM provider is rate limiting (enrichment will retry later)"
+        }
+        E::ParseError(_) => "the LLM response could not be parsed",
+        E::EmbeddingError(_) => "the embedding provider failed",
+        E::ProviderError(_) | E::HttpError(_) => {
+            "the LLM provider rejected the request, usually a provider or model mismatch \
+             (check llm_provider and llm_model)"
+        }
+    };
+    format!("Memory enrichment is paused: {cause}. Your memories are still saved.")
+}
+
 /// Serialize a MemoryNode to a JSON value with all fields.
 pub(crate) fn memory_node_to_json(mem: &MemoryNode) -> serde_json::Value {
     let attrs: serde_json::Map<String, serde_json::Value> = mem


### PR DESCRIPTION
## Summary
In local mode, a misconfigured or incompatible LLM provider could surface a raw low level validation string to the user (e.g. "Extraction failed: prompt is required when stop is not true"). That is confusing and gives no path to a fix. Enrichment already degrades gracefully (memories still store), so the user facing message should be clear and actionable, never the raw provider string.

## Changes
- Add friendly_extraction_error that maps each ExtractionError variant (auth, model not found, config, rate limit, provider rejection, parse, embedding) to a clear message with the setting to check, and reassurance that stored memories are safe
- Use it at the ingest tool leak points instead of the raw {e}

## Not changed (follow ups)
- The engine still logs the raw provider error at ERROR level in daemon logs (operator facing); downgrading that to an actionable WARN needs an engine release
- process_turn enrichment failures degrade silently; a one time in context notice would tell users enrichment is paused, but needs the engine enrichment result to report the reason

## Verification
- clippy clean with -D warnings, tests pass