### PR TITLE
chore: Dependabot parity + deps.rs badge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
-# Keeps the MCP server on the latest mentedb engine release.
-# Dependabot PRs the bump (manifest + lockfile), CI gates it, and merging
-# lets release-plz fold it into the next mentedb-mcp release, which rebuilds
-# and republishes the npm/crates binaries against the new engine.
+# Keeps mentedb-mcp current. Cargo: the mentedb engine bump is its own group
+# (a new engine release rebuilds and republishes the npm/crates binaries), all
+# other minor/patch bumps are grouped, and majors come as individual PRs. Plus
+# GitHub Actions. CI gates each one; merging lets release-plz cut the release.
 version: 2
 updates:
   - package-ecosystem: cargo
@@ -14,6 +14,21 @@ updates:
       mentedb-engine:
         patterns:
           - "mentedb*"
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - dependencies
     open-pull-requests-limit: 5

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The MCP (Model Context Protocol) server for MenteDB, the mind database for AI agents.
 
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+[![Crates.io](https://img.shields.io/crates/v/mentedb-mcp)](https://crates.io/crates/mentedb-mcp) [![CI](https://github.com/nambok/mentedb-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/nambok/mentedb-mcp/actions/workflows/ci.yml) [![dependency status](https://deps.rs/repo/github/nambok/mentedb-mcp/status.svg)](https://deps.rs/repo/github/nambok/mentedb-mcp) [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
 ## What is this?
 


### PR DESCRIPTION
mcp already had cargo Dependabot (it opened the recent bump PRs), but it lagged the engine's setup. Brings it to parity: adds the github-actions ecosystem (4 workflows had none), groups all cargo minor/patch bumps (keeping the mentedb-engine bump fast-tracked), and adds a live deps.rs dependency-status badge + CI/crates.io badges.