### PR TITLE
feat: named-account switching in the connector

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
 
 /// Resolve the data directory, expanding `~` to the user home.
 pub fn resolve_data_dir(raw: &str) -> PathBuf {
@@ -8,6 +11,154 @@ pub fn resolve_data_dir(raw: &str) -> PathBuf {
         return home.join(raw.trim_start_matches("~/"));
     }
     PathBuf::from(raw)
+}
+
+/// The default cloud API URL, used when an account does not pin its own.
+pub const DEFAULT_CLOUD_URL: &str = "https://api.mentedb.com";
+
+/// The name a migrated legacy single-key config is filed under.
+pub const DEFAULT_ACCOUNT: &str = "default";
+
+/// A single named MenteDB account. Each account is a distinct `mdb_` API key,
+/// which on the hosted side maps to a distinct engine and storage, so accounts
+/// are structurally isolated and never mixed.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Account {
+    /// The `mdb_` API key used as the bearer token for every request.
+    pub api_key: String,
+    /// Optional per-account cloud URL override. When absent, the process-wide
+    /// default (or the `MENTEDB_API_URL` env var) applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cloud_url: Option<String>,
+    /// Optional cached account email, shown by `accounts list` / `status`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+}
+
+/// The credentials file (`~/.mentedb/cloud.json`) as a set of named accounts.
+///
+/// Backward compatibility: the legacy shape `{ "api_url", "token" }` is read via
+/// [`AccountsConfig::from_json_str`], which migrates a lone legacy key into an
+/// account named [`DEFAULT_ACCOUNT`]. The migrated form is persisted on the next
+/// write, so old single-key installs keep working untouched until then.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AccountsConfig {
+    /// The account whose key the connector and all cloud operations use.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_account: Option<String>,
+    /// Named accounts, keyed by user-chosen name. `BTreeMap` keeps `list`
+    /// output and on-disk order stable.
+    #[serde(default)]
+    pub accounts: BTreeMap<String, Account>,
+}
+
+impl AccountsConfig {
+    /// Parse the credentials file, migrating the legacy single-key shape.
+    ///
+    /// - New shape (`accounts` present): parsed as-is.
+    /// - Legacy shape (`token`/`api_url`, no `accounts`): the key becomes the
+    ///   [`DEFAULT_ACCOUNT`] account and is made active.
+    /// - Empty / whitespace input: an empty config.
+    pub fn from_json_str(raw: &str) -> anyhow::Result<Self> {
+        if raw.trim().is_empty() {
+            return Ok(Self::default());
+        }
+
+        let value: serde_json::Value = serde_json::from_str(raw)?;
+
+        // New shape: an `accounts` object exists. Deserialize directly.
+        if value.get("accounts").is_some_and(|a| a.is_object()) {
+            let mut config: AccountsConfig = serde_json::from_value(value)?;
+            // Drop an active pointer that names a since-removed account so
+            // callers never resolve to a missing key.
+            if let Some(active) = &config.active_account
+                && !config.accounts.contains_key(active)
+            {
+                config.active_account = None;
+            }
+            return Ok(config);
+        }
+
+        // Legacy shape: a bare token (with optional api_url). Migrate it.
+        let mut config = AccountsConfig::default();
+        if let Some(token) = value.get("token").and_then(|t| t.as_str())
+            && !token.is_empty()
+        {
+            let cloud_url = value
+                .get("api_url")
+                .and_then(|u| u.as_str())
+                .filter(|u| !u.is_empty())
+                .map(str::to_string);
+            config.accounts.insert(
+                DEFAULT_ACCOUNT.to_string(),
+                Account {
+                    api_key: token.to_string(),
+                    cloud_url,
+                    email: None,
+                },
+            );
+            config.active_account = Some(DEFAULT_ACCOUNT.to_string());
+        }
+        Ok(config)
+    }
+
+    /// The active account name, falling back to a lone account or
+    /// [`DEFAULT_ACCOUNT`] when no explicit pointer is set.
+    pub fn active_name(&self) -> Option<String> {
+        if let Some(active) = &self.active_account
+            && self.accounts.contains_key(active)
+        {
+            return Some(active.clone());
+        }
+        // No explicit (or stale) pointer: a single account is unambiguous.
+        if self.accounts.len() == 1 {
+            return self.accounts.keys().next().cloned();
+        }
+        if self.accounts.contains_key(DEFAULT_ACCOUNT) {
+            return Some(DEFAULT_ACCOUNT.to_string());
+        }
+        None
+    }
+
+    /// The active account's name and credentials, if one resolves.
+    pub fn active_account(&self) -> Option<(&str, &Account)> {
+        let name = self.active_name()?;
+        // Re-borrow the key from the map so the returned `&str` is tied to the
+        // config, not the local `name`.
+        self.accounts
+            .get_key_value(&name)
+            .map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Serialize to the on-disk JSON (pretty, new multi-account shape).
+    pub fn to_json_string(&self) -> anyhow::Result<String> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+}
+
+/// Mask a secret for display without ever panicking on short values.
+/// Shows the first 12 characters (enough to see the `mdb_` prefix) then `...`.
+pub fn mask_secret(secret: &str) -> String {
+    let prefix: String = secret.chars().take(12).collect();
+    format!("{prefix}...")
+}
+
+/// Path to the credentials file (`<home>/.mentedb/cloud.json`) under a given
+/// config directory. Taking the directory as an argument keeps the config
+/// logic testable against a temp dir.
+pub fn credentials_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("cloud.json")
+}
+
+/// Load the accounts config from `<config_dir>/cloud.json`, migrating the
+/// legacy single-key shape. A missing file yields an empty config.
+pub fn load_accounts(config_dir: &Path) -> anyhow::Result<AccountsConfig> {
+    let path = credentials_path(config_dir);
+    if !path.exists() {
+        return Ok(AccountsConfig::default());
+    }
+    let raw = std::fs::read_to_string(&path)?;
+    AccountsConfig::from_json_str(&raw)
 }
 
 /// Server configuration parsed from CLI arguments and environment.
@@ -51,4 +202,209 @@ impl ServerConfig {
 
 fn dirs_home() -> Option<PathBuf> {
     std::env::var("HOME").ok().map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mirror what `upsert_account` in main.rs does: add or update an account
+    // on disk, optionally making it active. Kept here so the config round-trip
+    // (add -> reload -> use -> reload) is exercised end to end against a temp
+    // dir without pulling in the binary crate.
+    fn upsert(dir: &Path, name: &str, api_key: &str, cloud_url: Option<&str>, make_active: bool) {
+        let mut config = load_accounts(dir).unwrap();
+        let entry = config.accounts.entry(name.to_string()).or_default();
+        entry.api_key = api_key.to_string();
+        if let Some(url) = cloud_url {
+            entry.cloud_url = Some(url.to_string());
+        }
+        if make_active || config.active_account.is_none() {
+            config.active_account = Some(name.to_string());
+        }
+        std::fs::write(credentials_path(dir), config.to_json_string().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn migrates_legacy_single_key_to_default_account() {
+        // The old on-disk shape: a bare token plus api_url, no `accounts` map.
+        let legacy = r#"{ "api_url": "https://api.example.com", "token": "mdb_legacy_key_123" }"#;
+        let config = AccountsConfig::from_json_str(legacy).unwrap();
+
+        // Migrated into exactly one account named "default", made active.
+        assert_eq!(config.accounts.len(), 1);
+        let account = config
+            .accounts
+            .get(DEFAULT_ACCOUNT)
+            .expect("default account");
+        assert_eq!(account.api_key, "mdb_legacy_key_123");
+        assert_eq!(
+            account.cloud_url.as_deref(),
+            Some("https://api.example.com")
+        );
+        assert_eq!(config.active_account.as_deref(), Some(DEFAULT_ACCOUNT));
+
+        // active_account() resolves the migrated key.
+        let (name, active) = config.active_account().unwrap();
+        assert_eq!(name, DEFAULT_ACCOUNT);
+        assert_eq!(active.api_key, "mdb_legacy_key_123");
+    }
+
+    #[test]
+    fn migrates_legacy_key_without_api_url() {
+        let legacy = r#"{ "token": "mdb_only_token" }"#;
+        let config = AccountsConfig::from_json_str(legacy).unwrap();
+        let account = config.accounts.get(DEFAULT_ACCOUNT).unwrap();
+        assert_eq!(account.api_key, "mdb_only_token");
+        assert!(account.cloud_url.is_none());
+        assert_eq!(config.active_name().as_deref(), Some(DEFAULT_ACCOUNT));
+    }
+
+    #[test]
+    fn legacy_migration_persists_on_first_write() {
+        // A file written in the legacy shape is transparently upgraded to the
+        // multi-account shape the next time it is saved.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            credentials_path(dir.path()),
+            r#"{ "api_url": "https://api.example.com", "token": "mdb_legacy" }"#,
+        )
+        .unwrap();
+
+        // Load (migrates in memory) then add a second account (persists).
+        upsert(dir.path(), "work", "mdb_work_key", None, true);
+
+        // Re-read the raw file: it is now the new shape, with both accounts.
+        let raw = std::fs::read_to_string(credentials_path(dir.path())).unwrap();
+        assert!(raw.contains("\"accounts\""));
+        assert!(!raw.contains("\"token\"")); // legacy field gone
+        let reloaded = load_accounts(dir.path()).unwrap();
+        assert_eq!(reloaded.accounts.len(), 2);
+        assert!(reloaded.accounts.contains_key(DEFAULT_ACCOUNT));
+        assert!(reloaded.accounts.contains_key("work"));
+        assert_eq!(reloaded.active_name().as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn add_use_list_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // add "work" (first account becomes active implicitly).
+        upsert(
+            dir.path(),
+            "work",
+            "mdb_work_key",
+            Some("https://work.example.com"),
+            false,
+        );
+        // add "personal" (do not switch active).
+        upsert(dir.path(), "personal", "mdb_personal_key", None, false);
+
+        // list: both present, "work" is active.
+        let config = load_accounts(dir.path()).unwrap();
+        assert_eq!(config.accounts.len(), 2);
+        assert_eq!(config.active_name().as_deref(), Some("work"));
+        assert_eq!(
+            config.accounts["work"].cloud_url.as_deref(),
+            Some("https://work.example.com")
+        );
+        assert!(config.accounts["personal"].cloud_url.is_none());
+
+        // use "personal": set active, persist, reload.
+        let mut config = load_accounts(dir.path()).unwrap();
+        config.active_account = Some("personal".to_string());
+        std::fs::write(
+            credentials_path(dir.path()),
+            config.to_json_string().unwrap(),
+        )
+        .unwrap();
+
+        let reloaded = load_accounts(dir.path()).unwrap();
+        assert_eq!(reloaded.active_name().as_deref(), Some("personal"));
+        let (name, active) = reloaded.active_account().unwrap();
+        assert_eq!(name, "personal");
+        assert_eq!(active.api_key, "mdb_personal_key");
+        // The keys are structurally isolated: switching active never mixes them.
+        assert_ne!(active.api_key, reloaded.accounts["work"].api_key);
+    }
+
+    #[test]
+    fn remove_active_clears_pointer() {
+        let dir = tempfile::tempdir().unwrap();
+        upsert(dir.path(), "work", "mdb_work", None, true);
+        upsert(dir.path(), "personal", "mdb_personal", None, false);
+
+        // Remove the active account "work".
+        let mut config = load_accounts(dir.path()).unwrap();
+        config.accounts.remove("work");
+        config.active_account = None;
+        std::fs::write(
+            credentials_path(dir.path()),
+            config.to_json_string().unwrap(),
+        )
+        .unwrap();
+
+        let reloaded = load_accounts(dir.path()).unwrap();
+        assert!(!reloaded.accounts.contains_key("work"));
+        // With one account left, active resolves to it implicitly.
+        assert_eq!(reloaded.active_name().as_deref(), Some("personal"));
+    }
+
+    #[test]
+    fn active_name_falls_back_and_ignores_stale_pointer() {
+        // No explicit pointer, single account -> that account.
+        let mut config = AccountsConfig::default();
+        config.accounts.insert(
+            "solo".into(),
+            Account {
+                api_key: "k".into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(config.active_name().as_deref(), Some("solo"));
+
+        // A pointer naming a removed account is treated as unset (via parse).
+        let json = r#"{
+            "active_account": "gone",
+            "accounts": { "a": { "api_key": "ka" }, "b": { "api_key": "kb" } }
+        }"#;
+        let config = AccountsConfig::from_json_str(json).unwrap();
+        assert!(config.active_account.is_none());
+        // Two accounts, no valid pointer, no "default" -> ambiguous -> None.
+        assert!(config.active_name().is_none());
+    }
+
+    #[test]
+    fn empty_or_missing_config_is_empty() {
+        assert_eq!(
+            AccountsConfig::from_json_str("").unwrap(),
+            AccountsConfig::default()
+        );
+        assert_eq!(
+            AccountsConfig::from_json_str("   ").unwrap(),
+            AccountsConfig::default()
+        );
+        // Empty legacy token -> no account created.
+        let config = AccountsConfig::from_json_str(r#"{ "token": "" }"#).unwrap();
+        assert!(config.accounts.is_empty());
+        assert!(config.active_name().is_none());
+
+        // Missing file -> empty config.
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            load_accounts(dir.path()).unwrap(),
+            AccountsConfig::default()
+        );
+    }
+
+    #[test]
+    fn mask_secret_never_panics_and_hides_tail() {
+        assert_eq!(mask_secret("mdb_1234567890abcdef"), "mdb_12345678...");
+        // Short and empty inputs must not panic.
+        assert_eq!(mask_secret("mdb_"), "mdb_...");
+        assert_eq!(mask_secret(""), "...");
+        // The full secret is never present in the masked form.
+        let secret = "mdb_supersecrettail_zzzzzz";
+        assert!(!mask_secret(secret).contains("zzzzzz"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,11 @@ enum Commands {
     Login,
     /// Remove cloud credentials
     Logout,
+    /// Manage named MenteDB accounts (add, list, use, remove)
+    Accounts {
+        #[command(subcommand)]
+        command: AccountsCommand,
+    },
     /// Check cloud connection status
     Status,
     /// Diagnose the full memory pipeline (credentials, hooks, capture, spool)
@@ -137,6 +142,33 @@ enum Commands {
     /// Run the local hook daemon (owns the embedded database)
     #[cfg(feature = "local")]
     Daemon,
+}
+
+#[derive(Subcommand)]
+enum AccountsCommand {
+    /// Register a named account with an mdb_ API key (prompts if --key omitted)
+    Add {
+        /// Account name, e.g. "work" or "personal"
+        name: String,
+        /// The mdb_ API key. If omitted, you are prompted (key is not echoed).
+        #[arg(long)]
+        key: Option<String>,
+        /// Optional per-account cloud API URL override
+        #[arg(long)]
+        cloud_url: Option<String>,
+    },
+    /// List accounts, showing which is active (keys are masked)
+    List,
+    /// Set the active account (all cloud operations use its key)
+    Use {
+        /// Account name to activate
+        name: String,
+    },
+    /// Remove a named account
+    Remove {
+        /// Account name to remove
+        name: String,
+    },
 }
 
 #[derive(Clone, clap::ValueEnum)]
@@ -157,6 +189,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Update { client }) => return run_setup(client, true),
         Some(Commands::Login) => return run_login().await,
         Some(Commands::Logout) => return run_logout(),
+        Some(Commands::Accounts { command }) => return run_accounts(command).await,
         Some(Commands::Status) => return run_status().await,
         Some(Commands::Doctor) => {
             let data_dir = resolve_data_dir(&cli.data_dir);
@@ -595,26 +628,230 @@ async fn run_login() -> anyhow::Result<()> {
         }
     };
 
-    // Save to ~/.mentedb/cloud.json
-    let home = home_dir().unwrap_or_else(|| "~".to_string());
-    let mentedb_dir = std::path::PathBuf::from(&home).join(".mentedb");
-    std::fs::create_dir_all(&mentedb_dir)?;
+    // Save to ~/.mentedb/cloud.json, merging into the multi-account config.
+    // `login` targets the active account (or "default" when none is set), so
+    // it keeps behaving like a single-account login while `accounts add`
+    // manages the rest.
+    let dir = mentedb_dir().unwrap_or_else(|| std::path::PathBuf::from("~/.mentedb"));
+    std::fs::create_dir_all(&dir)?;
 
-    let cloud_config = serde_json::json!({
-        "api_url": std::env::var("MENTEDB_API_URL")
-            .unwrap_or_else(|_| "https://api.mentedb.com".to_string()),
-        "token": token,
-    });
-
-    let config_path = mentedb_dir.join("cloud.json");
-    write_secret_file(&config_path, &serde_json::to_string_pretty(&cloud_config)?)?;
+    let target = {
+        let config = config::load_accounts(&dir)?;
+        config
+            .active_name()
+            .unwrap_or_else(|| config::DEFAULT_ACCOUNT.to_string())
+    };
+    let cloud_url = std::env::var("MENTEDB_API_URL").ok();
+    let config_path = upsert_account(&dir, &target, &token, cloud_url, true)?;
 
     server_handle.abort();
 
     println!("  Authenticated successfully!");
+    println!("  Account: {target}");
     println!("  Credentials saved to: {}", config_path.display());
     println!("\n  Your MCP server will now sync with MenteDB Cloud.");
 
+    Ok(())
+}
+
+/// Insert or update a named account in `<dir>/cloud.json`, writing the file
+/// with 0600 permissions. When `make_active` is set (or no account is active
+/// yet) the account is also made active. Returns the credentials file path.
+fn upsert_account(
+    dir: &std::path::Path,
+    name: &str,
+    api_key: &str,
+    cloud_url: Option<String>,
+    make_active: bool,
+) -> anyhow::Result<std::path::PathBuf> {
+    let mut config = config::load_accounts(dir)?;
+    let entry = config.accounts.entry(name.to_string()).or_default();
+    entry.api_key = api_key.to_string();
+    // Only overwrite the stored URL when a new one was supplied, so re-running
+    // login does not clobber an account's pinned cloud_url.
+    if cloud_url.is_some() {
+        entry.cloud_url = cloud_url;
+    }
+    if make_active || config.active_account.is_none() {
+        config.active_account = Some(name.to_string());
+    }
+
+    let config_path = config::credentials_path(dir);
+    write_secret_file(&config_path, &config.to_json_string()?)?;
+    Ok(config_path)
+}
+
+/// Persist a fetched email onto an account, best-effort (never fails status).
+fn cache_account_email(dir: &std::path::Path, name: &str, email: &str) {
+    let Ok(mut config) = config::load_accounts(dir) else {
+        return;
+    };
+    if let Some(account) = config.accounts.get_mut(name) {
+        if account.email.as_deref() == Some(email) {
+            return; // Unchanged: avoid a needless write.
+        }
+        account.email = Some(email.to_string());
+        if let Ok(body) = config.to_json_string() {
+            write_secret_file(&config::credentials_path(dir), &body).ok();
+        }
+    }
+}
+
+/// Remove an account and, if it was active, clear the active pointer.
+/// Best-effort: used to drop a revoked account during `status`.
+fn remove_account_silent(dir: &std::path::Path, name: &str) {
+    let Ok(mut config) = config::load_accounts(dir) else {
+        return;
+    };
+    if config.accounts.remove(name).is_some() {
+        if config.active_account.as_deref() == Some(name) {
+            config.active_account = None;
+        }
+        if let Ok(body) = config.to_json_string() {
+            write_secret_file(&config::credentials_path(dir), &body).ok();
+        }
+    }
+}
+
+/// Dispatch `mentedb-mcp accounts <subcommand>`.
+async fn run_accounts(cmd: AccountsCommand) -> anyhow::Result<()> {
+    let dir = mentedb_dir().unwrap_or_else(|| std::path::PathBuf::from("~/.mentedb"));
+    match cmd {
+        AccountsCommand::Add {
+            name,
+            key,
+            cloud_url,
+        } => run_accounts_add(&dir, &name, key, cloud_url).await,
+        AccountsCommand::List => run_accounts_list(&dir),
+        AccountsCommand::Use { name } => run_accounts_use(&dir, &name),
+        AccountsCommand::Remove { name } => run_accounts_remove(&dir, &name),
+    }
+}
+
+/// Register (or update) a named account with an `mdb_` API key.
+async fn run_accounts_add(
+    dir: &std::path::Path,
+    name: &str,
+    key: Option<String>,
+    cloud_url: Option<String>,
+) -> anyhow::Result<()> {
+    if name.trim().is_empty() {
+        anyhow::bail!("Account name cannot be empty.");
+    }
+
+    // Take the key from the flag, else prompt. Never echo it back.
+    let key = match key {
+        Some(k) => k.trim().to_string(),
+        None => {
+            print!("  Paste the mdb_ API key for account '{name}': ");
+            use std::io::Write;
+            std::io::stdout().flush().ok();
+            let mut line = String::new();
+            std::io::stdin().read_line(&mut line)?;
+            line.trim().to_string()
+        }
+    };
+
+    if key.is_empty() {
+        anyhow::bail!("No API key provided.");
+    }
+    if !key.starts_with("mdb_") {
+        // A warning, not an error: keys are opaque and the prefix may change.
+        eprintln!("  [warn] key does not start with 'mdb_'; storing it anyway.");
+    }
+
+    std::fs::create_dir_all(dir)?;
+    let existed = config::load_accounts(dir)?.accounts.contains_key(name);
+    let config_path = upsert_account(dir, name, &key, cloud_url, false)?;
+
+    let verb = if existed { "Updated" } else { "Added" };
+    println!("  {verb} account '{name}' ({}).", config::mask_secret(&key));
+    // Report whether this became the active account.
+    let active = config::load_accounts(dir)?.active_name();
+    if active.as_deref() == Some(name) {
+        println!("  Active account is now '{name}'.");
+    } else if let Some(active) = active {
+        println!(
+            "  Active account remains '{active}'. Switch with `mentedb-mcp accounts use {name}`."
+        );
+    }
+    println!("  Saved to: {}", config_path.display());
+    Ok(())
+}
+
+/// List every account, marking the active one and masking keys.
+fn run_accounts_list(dir: &std::path::Path) -> anyhow::Result<()> {
+    let config = config::load_accounts(dir)?;
+    if config.accounts.is_empty() {
+        println!("  No accounts configured.");
+        println!("  Add one with `mentedb-mcp accounts add <name>` or `mentedb-mcp login`.");
+        return Ok(());
+    }
+
+    let active = config.active_name();
+    println!("  Accounts:");
+    for (name, account) in &config.accounts {
+        let marker = if active.as_deref() == Some(name.as_str()) {
+            "*"
+        } else {
+            " "
+        };
+        let email = account.email.as_deref().unwrap_or("-");
+        let url = account
+            .cloud_url
+            .as_deref()
+            .unwrap_or(config::DEFAULT_CLOUD_URL);
+        println!(
+            "  {marker} {name}  key={}  email={email}  url={url}",
+            config::mask_secret(&account.api_key)
+        );
+    }
+    println!("\n  (* = active)");
+    Ok(())
+}
+
+/// Set the active account.
+fn run_accounts_use(dir: &std::path::Path, name: &str) -> anyhow::Result<()> {
+    let mut config = config::load_accounts(dir)?;
+    if !config.accounts.contains_key(name) {
+        anyhow::bail!(
+            "No account named '{name}'. Run `mentedb-mcp accounts list` to see configured accounts."
+        );
+    }
+    config.active_account = Some(name.to_string());
+    std::fs::create_dir_all(dir)?;
+    write_secret_file(&config::credentials_path(dir), &config.to_json_string()?)?;
+    println!("  Active account is now '{name}'.");
+    Ok(())
+}
+
+/// Remove an account. Clears the active pointer if it named the removed one.
+fn run_accounts_remove(dir: &std::path::Path, name: &str) -> anyhow::Result<()> {
+    let mut config = config::load_accounts(dir)?;
+    if config.accounts.remove(name).is_none() {
+        anyhow::bail!(
+            "No account named '{name}'. Run `mentedb-mcp accounts list` to see configured accounts."
+        );
+    }
+    let was_active = config.active_account.as_deref() == Some(name);
+    if was_active {
+        config.active_account = None;
+    }
+    std::fs::create_dir_all(dir)?;
+    write_secret_file(&config::credentials_path(dir), &config.to_json_string()?)?;
+
+    println!("  Removed account '{name}'.");
+    if was_active {
+        if let Some(next) = config.active_name() {
+            // A single remaining account is resolved implicitly; make that
+            // explicit so later commands are unambiguous.
+            config.active_account = Some(next.clone());
+            write_secret_file(&config::credentials_path(dir), &config.to_json_string()?)?;
+            println!("  Active account is now '{next}'.");
+        } else if !config.accounts.is_empty() {
+            println!("  No active account set. Choose one with `mentedb-mcp accounts use <name>`.");
+        }
+    }
     Ok(())
 }
 
@@ -633,9 +870,8 @@ fn run_logout() -> anyhow::Result<()> {
 }
 
 async fn run_status() -> anyhow::Result<()> {
-    let home = home_dir().unwrap_or_else(|| "~".to_string());
-    let mentedb_dir = std::path::PathBuf::from(&home).join(".mentedb");
-    let config_path = mentedb_dir.join("cloud.json");
+    let dir = mentedb_dir().unwrap_or_else(|| std::path::PathBuf::from("~/.mentedb"));
+    let config_path = config::credentials_path(&dir);
 
     if !config_path.exists() {
         println!("  Status: Not logged in");
@@ -643,20 +879,33 @@ async fn run_status() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let config_str = std::fs::read_to_string(&config_path)?;
-    let config: serde_json::Value = serde_json::from_str(&config_str)?;
+    let config = config::load_accounts(&dir)?;
+    let Some((active_name, account)) = config.active_account() else {
+        if config.accounts.is_empty() {
+            println!("  Status: Not logged in");
+            println!("  Run `mentedb-mcp login` to authenticate.");
+        } else {
+            println!("  Status: No active account");
+            println!("  Run `mentedb-mcp accounts use <name>` to select one.");
+        }
+        return Ok(());
+    };
+    let active_name = active_name.to_string();
 
-    let api_url = config["api_url"]
-        .as_str()
-        .unwrap_or("https://api.mentedb.com");
-    let token = config["token"].as_str().unwrap_or("");
-
+    let token = account.api_key.clone();
     if token.is_empty() {
-        println!("  Status: Invalid credentials (empty token)");
+        println!("  Status: Invalid credentials (empty key)");
         println!("  Run `mentedb-mcp login` to re-authenticate.");
         return Ok(());
     }
+    // MENTEDB_API_URL overrides the account's pinned URL, matching how
+    // credentials are loaded for actual requests.
+    let api_url = std::env::var("MENTEDB_API_URL")
+        .ok()
+        .or_else(|| account.cloud_url.clone())
+        .unwrap_or_else(|| config::DEFAULT_CLOUD_URL.to_string());
 
+    println!("  Active account: {active_name}");
     println!("  Checking cloud connection...");
 
     let client = reqwest::Client::new();
@@ -672,7 +921,7 @@ async fn run_status() -> anyhow::Result<()> {
             200 => {
                 println!("  Status: Connected");
                 println!("  Cloud URL: {api_url}");
-                println!("  Token: {}", mask_token(token));
+                println!("  Key: {}", config::mask_secret(&token));
 
                 // Fetch account info
                 match client
@@ -685,7 +934,10 @@ async fn run_status() -> anyhow::Result<()> {
                     Ok(me_resp) if me_resp.status().is_success() => {
                         if let Ok(me) = me_resp.json::<serde_json::Value>().await {
                             if let Some(email) = me.get("email").and_then(|v| v.as_str()) {
-                                println!("  Account: {email}");
+                                println!("  Email: {email}");
+                                // Cache the email on the account for offline
+                                // `accounts list` display.
+                                cache_account_email(&dir, &active_name, email);
                             }
                             if let Some(plan) = me.get("plan").and_then(|v| v.as_str()) {
                                 println!("  Plan: {plan}");
@@ -700,8 +952,8 @@ async fn run_status() -> anyhow::Result<()> {
                 println!();
                 println!("  Your session has been revoked (possibly from the web dashboard).");
                 println!("  Run `mentedb-mcp login` to create a new session.");
-                // Remove stale credentials
-                std::fs::remove_file(&config_path).ok();
+                // Remove only the stale account, preserving the others.
+                remove_account_silent(&dir, &active_name);
             }
             code => {
                 println!("  Status: Error (HTTP {code})");
@@ -722,39 +974,32 @@ async fn run_status() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Load cloud credentials from ~/.mentedb/cloud.json.
-/// Returns (api_url, token) if valid credentials exist.
-/// Also checks the MENTEDB_API_URL env var as an override for the API URL.
-fn load_cloud_credentials() -> Option<(String, String)> {
-    let home = home_dir()?;
-    let config_path = std::path::PathBuf::from(&home)
-        .join(".mentedb")
-        .join("cloud.json");
-    if !config_path.exists() {
-        return None;
-    }
-
-    let config_str = std::fs::read_to_string(&config_path).ok()?;
-    let config: serde_json::Value = serde_json::from_str(&config_str).ok()?;
-
-    let token = config["token"].as_str().unwrap_or_default();
-    if token.is_empty() {
-        return None;
-    }
-
-    // MENTEDB_API_URL env var takes precedence over stored api_url
-    let api_url = std::env::var("MENTEDB_API_URL")
-        .ok()
-        .or_else(|| config["api_url"].as_str().map(String::from))
-        .unwrap_or_else(|| "https://api.mentedb.com".to_string());
-
-    Some((api_url, token.to_string()))
+/// Directory holding MenteDB credentials and state (`~/.mentedb`).
+fn mentedb_dir() -> Option<std::path::PathBuf> {
+    Some(std::path::PathBuf::from(home_dir()?).join(".mentedb"))
 }
 
-/// Mask a token for display without ever panicking on short values.
-fn mask_token(token: &str) -> String {
-    let prefix: String = token.chars().take(12).collect();
-    format!("{prefix}...")
+/// Load cloud credentials for the ACTIVE account from ~/.mentedb/cloud.json.
+/// Returns (api_url, token) if a valid active account exists.
+///
+/// The legacy single-key shape is migrated on read (see
+/// `config::AccountsConfig`), so pre-existing single-key installs keep working.
+/// Also checks the MENTEDB_API_URL env var as an override for the API URL.
+fn load_cloud_credentials() -> Option<(String, String)> {
+    let dir = mentedb_dir()?;
+    let config = config::load_accounts(&dir).ok()?;
+    let (_, account) = config.active_account()?;
+    if account.api_key.is_empty() {
+        return None;
+    }
+
+    // MENTEDB_API_URL env var takes precedence over the account's cloud_url.
+    let api_url = std::env::var("MENTEDB_API_URL")
+        .ok()
+        .or_else(|| account.cloud_url.clone())
+        .unwrap_or_else(|| config::DEFAULT_CLOUD_URL.to_string());
+
+    Some((api_url, account.api_key.clone()))
 }
 
 /// Write a credentials file created with 0600 from the first byte, instead
@@ -794,7 +1039,7 @@ async fn run_doctor(data_dir: &std::path::Path) -> anyhow::Result<()> {
         Some((api_url, token)) => {
             println!(
                 "  [ok]   Cloud credentials: {} ({})",
-                mask_token(token),
+                config::mask_secret(token),
                 api_url
             );
             let client = reqwest::Client::new();


### PR DESCRIPTION
Register multiple MenteDB accounts (each an mdb_ key) and switch the active one; connector/daemon/hooks use one account at a time, never mixed. Backward compatible (legacy single key -> 'default'). 43 tests, clippy clean.