### PR TITLE
chore: run npm publish workflow on Node 24

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -104,7 +104,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Sync versions from Cargo.toml


### PR DESCRIPTION
## Summary
- Pin the npm publish workflow to Node 24 (was `lts/*`).

## Changes
- `npm-publish.yml`: `node-version: lts/*` -> `24`.

## Verification
- YAML-only; takes effect on the next publish run.