### PR TITLE
fix(hook): bound the spool flush so a backlog cannot block a prompt

### DIFF
--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -423,17 +423,30 @@ fn auth_notice(data_dir: &Path) -> Option<String> {
 /// still fail (and everything after the first failure, to preserve order) go
 /// back into the spool.
 async fn flush_spool(data_dir: &Path, backend: &Backend) {
+    // The flush is bounded so a backlog never dominates a hook: at most
+    // MAX_FLUSH_PER_CALL entries and at most FLUSH_BUDGET of wall-clock per
+    // invocation. Whatever is not reached stays spooled for the next hook, so a
+    // large backlog drains over several hooks instead of blocking one prompt for
+    // tens of seconds (each store is a full round trip; N of them was the hang).
+    const MAX_FLUSH_PER_CALL: usize = 25;
+    const FLUSH_BUDGET: std::time::Duration = std::time::Duration::from_secs(6);
+
     let entries = spool::take_all(data_dir);
     if entries.is_empty() {
         return;
     }
+    let start = std::time::Instant::now();
+    let mut processed = 0usize;
     let mut failed: Vec<serde_json::Value> = Vec::new();
     let mut hit_failure = false;
     for e in entries {
-        if hit_failure {
+        // Stop making network calls once we fail, reach the item cap, or exceed
+        // the time budget; everything remaining is requeued in order.
+        if hit_failure || processed >= MAX_FLUSH_PER_CALL || start.elapsed() >= FLUSH_BUDGET {
             failed.push(e);
             continue;
         }
+        processed += 1;
         let ok = match e.get("kind").and_then(|v| v.as_str()) {
             Some("turn") => {
                 let user = e.get("user_message").and_then(|v| v.as_str()).unwrap_or("");


### PR DESCRIPTION
## Problem
`flush_spool` took the entire spool (`take_all`) and processed every entry sequentially with only a per-item timeout and a stop-on-first-failure guard. When the backend is reachable but slow (each `store_turn`/`store_note` is a full round trip, ~1s), a backlog of dozens of entries drained in **one** call took tens of seconds and hit the hook's 30s timeout, blocking every prompt. A single dropped write during a deploy could seed a backlog that then degraded every subsequent turn (`retained` climbing across a session).

## Fix
Bound each flush: at most **25 entries** and **6s of wall-clock** per invocation. Whatever is not reached stays spooled and drains over subsequent hooks, so a large backlog can never block one prompt. It is a one-shot hook process, so backgrounding is not viable; capping is the right lever.

## Verification
- `cargo clippy -- -D warnings`: clean. `cargo test`: 43 passed.
- Root-caused from a live 30s-timeout report: token valid + cloud fast (0.08s), but 76 small write-entries stuck in the local spool, re-flushed synchronously every prompt.