### PR TITLE
feat(hook): warn in-session when the write spool backs up

### DIFF
--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -229,6 +229,16 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
                     format!("{notice}\n\n{text}")
                 };
             }
+            // Surface a stalled write spool in the session itself, so a sync
+            // outage is visible immediately instead of silently dropping turns
+            // for hours. Prepended above any recalled context so it reads first.
+            if let Some(warning) = spool_notice(data_dir) {
+                text = if text.is_empty() {
+                    warning
+                } else {
+                    format!("{warning}\n\n{text}")
+                };
+            }
             if !text.is_empty() {
                 println!(
                     "{}",
@@ -416,6 +426,25 @@ fn auth_notice(data_dir: &Path) -> Option<String> {
          Tell the user to run `npx mentedb-mcp@latest login` to reconnect. \
          New memories are spooling locally and will sync automatically after login."
             .to_string()
+    })
+}
+
+/// When the local write spool has backed up past a small threshold, the cloud
+/// is not accepting writes and recent turns are not being remembered. Surface
+/// that in the session so a sync outage never stays silent for hours; the hook
+/// keeps retrying on its own and the notice clears once the backlog drains.
+fn spool_notice(data_dir: &Path) -> Option<String> {
+    // A retry or two is normal and self-heals within a prompt, so only warn once
+    // a real backlog has formed and this never cries wolf on a transient blip.
+    const SPOOL_WARN_THRESHOLD: usize = 10;
+    let queued = spool::depth(data_dir);
+    (queued >= SPOOL_WARN_THRESHOLD).then(|| {
+        format!(
+            "MenteDB sync warning: {queued} memories are queued locally and have not synced \
+             to the cloud, so recent turns from this session may not be remembered yet. The \
+             hook keeps retrying automatically; if this persists, check \
+             ~/.mentedb/mentedb-hook.log."
+        )
     })
 }
 


### PR DESCRIPTION
## Summary
When cloud writes fail, the hook spools stores locally and retries, but nothing surfaced to the user, so a multi-hour sync outage stayed invisible (it only showed as a stale turn counter in the admin). This adds an in-session banner so a stalled sync is obvious immediately.

## Changes
- Add `spool_notice()` (mirrors `auth_notice`): returns a warning when `spool::depth()` is at or above a small threshold (10 queued entries).
- Prepend it to the UserPromptSubmit `additionalContext`, above any recalled memory, so it reads first. It clears on its own once the backlog drains.

## Verification
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo build`: all clean.
- No emojis or dashes in the notice text, per repo convention.