### PR TITLE
fix(login): make the browser path clear and the pasted code SSH-only

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -572,9 +572,11 @@ async fn run_login() -> anyhow::Result<()> {
         std::env::var("MENTEDB_API_URL").unwrap_or_else(|_| "https://api.mentedb.com".to_string());
 
     println!("\n  Waiting for authorization...");
-    println!("  On SSH or a remote machine, the browser cannot reach this process.");
-    println!("  In that case the page shows a connection code after you authorize.");
-    println!("  Paste it here and press Enter:\n");
+    println!("  Approve in the browser and this finishes on its own.");
+    println!();
+    println!("  Only on SSH or a remote machine, where the browser cannot reach this");
+    println!("  terminal, the page shows a code after you approve; paste it here:");
+    println!();
 
     // Whichever arrives first wins: the browser callback (same machine) or a
     // manually pasted connection code (SSH and remote sessions).


### PR DESCRIPTION
## Summary
The device-login prompt printed the SSH/remote fallback and "Paste it here and press Enter" on every login, so a normal browser login looked like it required pasting a code (the user flagged this as confusing).

## Changes
- Primary path now reads "Approve in the browser and this finishes on its own."
- The connection-code paste instruction is scoped to the SSH/remote case where the browser cannot reach the terminal.

## Verification
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo build`: all clean.