### PR TITLE
feat: write-time selectivity, show-why context, and status command

### DIFF
--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -61,10 +61,12 @@ struct SessionState {
     /// reporting when the turn's reply arrives at Stop.
     #[serde(default)]
     last_injected: Vec<String>,
-    /// Last stored action note, to collapse consecutive duplicates
-    /// (iterating on one file should not produce N identical memories).
+    /// Hashes of recently stored action notes, newest last, to collapse
+    /// repeats (iterating on one file should not produce N identical
+    /// memories). A window rather than only the previous note, because work
+    /// ping-pongs: edit A, run tests, edit A again.
     #[serde(default)]
-    last_note: Option<String>,
+    recent_note_hashes: Vec<u64>,
 }
 
 /// Claude Code injects background task notifications, system reminders, and
@@ -272,7 +274,14 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
             // skips periodic maintenance for it.
             state.turn_id += 1;
             let turn_id = state.turn_id;
-            state.last_user_message = Some(user_message.chars().take(600).collect());
+            // Short acknowledgements are not worth a turn memory, and they
+            // also stay out of last_user_message: blending "ok" into the next
+            // recall query would ground it in nothing.
+            let store_turn = worth_storing_turn(&user_message);
+            if store_turn {
+                state.last_user_message = Some(user_message.chars().take(600).collect());
+            }
+            let outcome_ids = std::mem::take(&mut state.last_injected);
             save_state(data_dir, &session_id, &state);
 
             let project = payload
@@ -282,9 +291,6 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
                 .and_then(|n| n.to_str())
                 .map(str::to_string);
 
-            let outcome_ids = std::mem::take(&mut state.last_injected);
-            save_state(data_dir, &session_id, &state);
-
             // Spool the turn (and attention outcome) first so they are durable
             // regardless of the network, then flush synchronously. Each send is
             // bounded by a tight per-send timeout inside flush_spool, so the turn
@@ -292,17 +298,19 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
             // the 30s client timeout, worse when flaky). Anything that does not
             // send in time stays spooled and the next hook flushes it, so nothing
             // is lost.
-            spool::push(
-                data_dir,
-                &json!({
-                    "kind": "turn",
-                    "user_message": user_message,
-                    "assistant_response": assistant.clone(),
-                    "turn_id": turn_id,
-                    "project": project,
-                    "session_id": session_id,
-                }),
-            );
+            if store_turn {
+                spool::push(
+                    data_dir,
+                    &json!({
+                        "kind": "turn",
+                        "user_message": user_message,
+                        "assistant_response": assistant.clone(),
+                        "turn_id": turn_id,
+                        "project": project,
+                        "session_id": session_id,
+                    }),
+                );
+            }
             if !outcome_ids.is_empty() {
                 spool::push(
                     data_dir,
@@ -355,13 +363,12 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
             };
             let note = redact(&note);
 
-            // Iterating on one file fires this hook repeatedly with the
-            // identical note; one memory carries all the information.
+            // Iterating on a handful of files fires this hook repeatedly with
+            // the same few notes; one memory each carries all the information.
             let mut state = load_state(data_dir, &session_id);
-            if state.last_note.as_deref() == Some(note.as_str()) {
+            if note_seen_recently(&mut state.recent_note_hashes, &note) {
                 return Ok(());
             }
-            state.last_note = Some(note.clone());
             save_state(data_dir, &session_id, &state);
 
             let project = payload
@@ -429,14 +436,17 @@ fn auth_notice(data_dir: &Path) -> Option<String> {
     })
 }
 
+/// Spool depth at which the backlog is a real outage rather than a transient
+/// blip. A retry or two is normal and self-heals within a prompt, so warning
+/// (and failing `status`) below this would cry wolf. Shared with the `status`
+/// command so its exit code and the in-session warning agree.
+pub(crate) const SPOOL_WARN_THRESHOLD: usize = 10;
+
 /// When the local write spool has backed up past a small threshold, the cloud
 /// is not accepting writes and recent turns are not being remembered. Surface
 /// that in the session so a sync outage never stays silent for hours; the hook
 /// keeps retrying on its own and the notice clears once the backlog drains.
 fn spool_notice(data_dir: &Path) -> Option<String> {
-    // A retry or two is normal and self-heals within a prompt, so only warn once
-    // a real backlog has formed and this never cries wolf on a transient blip.
-    const SPOOL_WARN_THRESHOLD: usize = 10;
     let queued = spool::depth(data_dir);
     (queued >= SPOOL_WARN_THRESHOLD).then(|| {
         format!(
@@ -591,6 +601,61 @@ const READ_ONLY_BASH: &[&str] = &[
     "du",
 ];
 
+/// Bash command prefixes that mutate state but carry no durable signal:
+/// formatting, linting, and build invocations fire constantly while iterating
+/// and describe the toolchain, not the work. Pure git state reads are already
+/// skipped via READ_ONLY_BASH above; this list follows the same lowercase
+/// prefix-match pattern.
+const LOW_INFO_BASH: &[&str] = &[
+    "cargo fmt",
+    "cargo clippy",
+    "cargo check",
+    "cargo build",
+    "npm run lint",
+    "npm run build",
+    "npx prettier",
+    "prettier",
+    "npx eslint",
+    "eslint",
+];
+
+/// How many recent action-note hashes each session remembers for dedupe.
+/// Work ping-pongs between a handful of files and commands, so exact-repeat
+/// suppression needs more than the single previous note; 8 covers a typical
+/// edit-test loop while staying too small to ever suppress genuinely new work.
+const NOTE_DEDUPE_WINDOW: usize = 8;
+
+/// Rolling-window dedupe for action notes: true when this note was already
+/// stored recently. Otherwise records the note's hash and trims the window.
+/// Hashes rather than full notes keep the session state file small.
+fn note_seen_recently(recent_hashes: &mut Vec<u64>, note: &str) -> bool {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    note.hash(&mut hasher);
+    let hash = hasher.finish();
+    if recent_hashes.contains(&hash) {
+        return true;
+    }
+    recent_hashes.push(hash);
+    let excess = recent_hashes.len().saturating_sub(NOTE_DEDUPE_WINDOW);
+    if excess > 0 {
+        recent_hashes.drain(..excess);
+    }
+    false
+}
+
+/// Prompts below this length ("ok", "yes", "do it") are pure acknowledgement:
+/// they carry no retrievable content of their own, and the recall side already
+/// blends the previous turn into short follow-up queries, so storing them only
+/// creates junk turn memories.
+const MIN_STORED_PROMPT_CHARS: usize = 12;
+
+/// Whether a stripped, redacted user prompt is substantial enough to store
+/// as a turn.
+fn worth_storing_turn(user_message: &str) -> bool {
+    user_message.chars().count() >= MIN_STORED_PROMPT_CHARS
+}
+
 /// Build a compact memory note for a significant tool action, or None for
 /// tools not worth remembering (reads, searches, navigation).
 fn summarize_tool_action(payload: &serde_json::Value) -> Option<String> {
@@ -610,6 +675,9 @@ fn summarize_tool_action(payload: &serde_json::Value) -> Option<String> {
             }
             let lower = cmd.to_lowercase();
             if READ_ONLY_BASH.iter().any(|p| lower.starts_with(p)) {
+                return None;
+            }
+            if LOW_INFO_BASH.iter().any(|p| lower.starts_with(p)) {
                 return None;
             }
             let compact: String = cmd.chars().take(200).collect();
@@ -789,6 +857,33 @@ fn now_micros() -> u64 {
         .as_micros() as u64
 }
 
+/// Compact show-why suffix for an injected memory line: where it came from
+/// and why it was selected, when the backend provides those fields. The
+/// memory type already leads the line, so it is not repeated here. With no
+/// fields present the suffix is empty and the line renders exactly as before.
+/// Deliberately terse, every character costs prompt tokens.
+fn provenance_suffix(m: &serde_json::Value) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(project) = m.get("project").and_then(|v| v.as_str())
+        && !project.is_empty()
+    {
+        parts.push(project.to_string());
+    }
+    if let Some(reason) = m.get("reason").and_then(|v| v.as_str())
+        && !reason.is_empty()
+    {
+        parts.push(reason.to_string());
+    }
+    if let Some(score) = m.get("score").and_then(|v| v.as_f64()) {
+        parts.push(format!("{score:.2}"));
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" [{}]", parts.join(", "))
+    }
+}
+
 /// Render backend context JSON ({memories: [...], pain: [...]}) into the text
 /// injected into the model context. Returns None when there is nothing worth
 /// injecting.
@@ -807,7 +902,12 @@ fn format_context(ctx: &serde_json::Value) -> Option<String> {
                 .get("memory_type")
                 .and_then(|v| v.as_str())
                 .unwrap_or("memory");
-            let line = format!("- [{}] {}\n", mtype.to_lowercase(), content);
+            let line = format!(
+                "- [{}] {}{}\n",
+                mtype.to_lowercase(),
+                content,
+                provenance_suffix(m)
+            );
             if out.len() + line.len() > CONTEXT_CHAR_BUDGET {
                 break;
             }
@@ -965,6 +1065,98 @@ mod tests {
             summarize_tool_action(&bash).as_deref(),
             Some("Ran command: cargo test --workspace")
         );
+    }
+
+    #[test]
+    fn format_context_appends_show_why_suffix() {
+        let ctx = json!({ "memories": [
+            {
+                "content": "User prefers Rust",
+                "memory_type": "Semantic",
+                "project": "apex",
+                "reason": "pinned",
+                "score": 0.8234,
+            },
+            { "content": "plain memory", "memory_type": "Semantic" },
+        ]});
+        let text = format_context(&ctx).unwrap();
+        assert!(text.contains("- [semantic] User prefers Rust [apex, pinned, 0.82]"));
+        // Without metadata the line renders exactly as before.
+        assert!(text.contains("- [semantic] plain memory\n"));
+    }
+
+    #[test]
+    fn provenance_suffix_renders_partial_fields() {
+        assert_eq!(provenance_suffix(&json!({})), "");
+        assert_eq!(provenance_suffix(&json!({ "project": "apex" })), " [apex]");
+        assert_eq!(
+            provenance_suffix(&json!({ "reason": "pinned" })),
+            " [pinned]"
+        );
+        assert_eq!(
+            provenance_suffix(&json!({ "project": "apex", "score": 0.5 })),
+            " [apex, 0.50]"
+        );
+        // Non-string and empty fields are ignored, never rendered.
+        assert_eq!(
+            provenance_suffix(&json!({ "project": "", "score": "hi" })),
+            ""
+        );
+    }
+
+    #[test]
+    fn note_dedupe_window_skips_repeats_within_window() {
+        let mut recent = Vec::new();
+        assert!(!note_seen_recently(&mut recent, "Edited file: a.rs"));
+        assert!(!note_seen_recently(&mut recent, "Ran command: cargo test"));
+        // A repeat within the window is suppressed even when not adjacent.
+        assert!(note_seen_recently(&mut recent, "Edited file: a.rs"));
+
+        // Enough distinct notes evict the oldest entry, which then stores again.
+        for i in 0..NOTE_DEDUPE_WINDOW {
+            assert!(!note_seen_recently(&mut recent, &format!("note {i}")));
+        }
+        assert!(recent.len() <= NOTE_DEDUPE_WINDOW);
+        assert!(!note_seen_recently(&mut recent, "Edited file: a.rs"));
+    }
+
+    #[test]
+    fn summarize_tool_action_skips_low_information_commands() {
+        for cmd in [
+            "cargo fmt --all",
+            "cargo clippy -- -D warnings",
+            "cargo build --release",
+            "npm run lint",
+            "npx prettier --write .",
+            "prettier --check src",
+            "eslint src/",
+        ] {
+            let p = json!({ "tool_name": "Bash", "tool_input": { "command": cmd } });
+            assert!(summarize_tool_action(&p).is_none(), "should skip: {cmd}");
+        }
+        // Meaningful commands are still captured.
+        for cmd in [
+            "cargo test --workspace",
+            "npm install left-pad",
+            "git commit -m x",
+        ] {
+            let p = json!({ "tool_name": "Bash", "tool_input": { "command": cmd } });
+            assert!(summarize_tool_action(&p).is_some(), "should keep: {cmd}");
+        }
+    }
+
+    #[test]
+    fn short_prompts_are_not_worth_storing() {
+        for p in ["", "ok", "yes", "do it", "lgtm"] {
+            assert!(!worth_storing_turn(p), "should skip: {p:?}");
+        }
+        for p in [
+            "fix the bug!",
+            "fix the login bug",
+            "why does the daemon restart",
+        ] {
+            assert!(worth_storing_turn(p), "should keep: {p:?}");
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ enum Commands {
         #[command(subcommand)]
         command: AccountsCommand,
     },
-    /// Check cloud connection status
+    /// Print a compact health block from local state (exit 1 when unhealthy)
     Status,
     /// Diagnose the full memory pipeline (credentials, hooks, capture, spool)
     Doctor,
@@ -190,7 +190,10 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Login) => return run_login().await,
         Some(Commands::Logout) => return run_logout(),
         Some(Commands::Accounts { command }) => return run_accounts(command).await,
-        Some(Commands::Status) => return run_status().await,
+        Some(Commands::Status) => {
+            let data_dir = resolve_data_dir(&cli.data_dir);
+            return run_status(&data_dir).await;
+        }
         Some(Commands::Doctor) => {
             let data_dir = resolve_data_dir(&cli.data_dir);
             return run_doctor(&data_dir).await;
@@ -683,38 +686,6 @@ fn upsert_account(
     Ok(config_path)
 }
 
-/// Persist a fetched email onto an account, best-effort (never fails status).
-fn cache_account_email(dir: &std::path::Path, name: &str, email: &str) {
-    let Ok(mut config) = config::load_accounts(dir) else {
-        return;
-    };
-    if let Some(account) = config.accounts.get_mut(name) {
-        if account.email.as_deref() == Some(email) {
-            return; // Unchanged: avoid a needless write.
-        }
-        account.email = Some(email.to_string());
-        if let Ok(body) = config.to_json_string() {
-            write_secret_file(&config::credentials_path(dir), &body).ok();
-        }
-    }
-}
-
-/// Remove an account and, if it was active, clear the active pointer.
-/// Best-effort: used to drop a revoked account during `status`.
-fn remove_account_silent(dir: &std::path::Path, name: &str) {
-    let Ok(mut config) = config::load_accounts(dir) else {
-        return;
-    };
-    if config.accounts.remove(name).is_some() {
-        if config.active_account.as_deref() == Some(name) {
-            config.active_account = None;
-        }
-        if let Ok(body) = config.to_json_string() {
-            write_secret_file(&config::credentials_path(dir), &body).ok();
-        }
-    }
-}
-
 /// Dispatch `mentedb-mcp accounts <subcommand>`.
 async fn run_accounts(cmd: AccountsCommand) -> anyhow::Result<()> {
     let dir = mentedb_dir().unwrap_or_else(|| std::path::PathBuf::from("~/.mentedb"));
@@ -871,109 +842,162 @@ fn run_logout() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn run_status() -> anyhow::Result<()> {
-    let dir = mentedb_dir().unwrap_or_else(|| std::path::PathBuf::from("~/.mentedb"));
-    let config_path = config::credentials_path(&dir);
+/// Compact health block built from local state only: files under the data
+/// directory plus two cheap liveness probes (daemon TCP port, cloud /health).
+/// No authenticated calls, no new server endpoints. Exits 1 when unhealthy
+/// (spool backlog or auth error) so scripts can gate on it.
+async fn run_status(data_dir: &std::path::Path) -> anyhow::Result<()> {
+    // A liveness probe, not a real API call; anything slower than this is
+    // effectively down for interactive use.
+    const CLOUD_HEALTH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+    // The daemon is on loopback, so a live one accepts a TCP connection
+    // near-instantly; a longer wait only slows down the "not running" answer.
+    const DAEMON_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
 
-    if !config_path.exists() {
-        println!("  Status: Not logged in");
-        println!("  Run `mentedb-mcp login` to authenticate.");
-        return Ok(());
+    println!("\nMenteDB status v{}\n", env!("CARGO_PKG_VERSION"));
+    println!("  Data dir:   {}", data_dir.display());
+
+    let depth = hook::spool::depth(data_dir);
+    if depth == 0 {
+        println!("  Spool:      empty");
+    } else {
+        println!("  Spool:      {depth} queued");
     }
 
-    let config = config::load_accounts(&dir)?;
-    let Some((active_name, account)) = config.active_account() else {
-        if config.accounts.is_empty() {
-            println!("  Status: Not logged in");
-            println!("  Run `mentedb-mcp login` to authenticate.");
-        } else {
-            println!("  Status: No active account");
-            println!("  Run `mentedb-mcp accounts use <name>` to select one.");
-        }
-        return Ok(());
-    };
-    let active_name = active_name.to_string();
-
-    let token = account.api_key.clone();
-    if token.is_empty() {
-        println!("  Status: Invalid credentials (empty key)");
-        println!("  Run `mentedb-mcp login` to re-authenticate.");
-        return Ok(());
+    // The hook writes this marker on authentication failure and clears it on
+    // the next successful call (see record_auth_state in src/hook/mod.rs).
+    let auth_ok = !data_dir.join("auth_error").exists();
+    if auth_ok {
+        println!("  Auth:       ok");
+    } else {
+        println!("  Auth:       session invalid, run `mentedb-mcp login`");
     }
-    // MENTEDB_API_URL overrides the account's pinned URL, matching how
-    // credentials are loaded for actual requests.
-    let api_url = std::env::var("MENTEDB_API_URL")
+
+    // Daemon liveness from daemon.json, parsed directly (not via the daemon
+    // module) so this also works in cloud-only builds without local mode.
+    let daemon_port = std::fs::read_to_string(data_dir.join("daemon.json"))
         .ok()
-        .or_else(|| account.cloud_url.clone())
-        .unwrap_or_else(|| config::DEFAULT_CLOUD_URL.to_string());
-
-    println!("  Active account: {active_name}");
-    println!("  Checking cloud connection...");
-
-    let client = reqwest::Client::new();
-    let res = client
-        .get(format!("{api_url}/api/sessions"))
-        .header("Authorization", format!("Bearer {token}"))
-        .timeout(std::time::Duration::from_secs(10))
-        .send()
-        .await;
-
-    match res {
-        Ok(resp) => match resp.status().as_u16() {
-            200 => {
-                println!("  Status: Connected");
-                println!("  Cloud URL: {api_url}");
-                println!("  Key: {}", config::mask_secret(&token));
-
-                // Fetch account info
-                match client
-                    .get(format!("{api_url}/api/me"))
-                    .header("Authorization", format!("Bearer {token}"))
-                    .timeout(std::time::Duration::from_secs(5))
-                    .send()
-                    .await
-                {
-                    Ok(me_resp) if me_resp.status().is_success() => {
-                        if let Ok(me) = me_resp.json::<serde_json::Value>().await {
-                            if let Some(email) = me.get("email").and_then(|v| v.as_str()) {
-                                println!("  Email: {email}");
-                                // Cache the email on the account for offline
-                                // `accounts list` display.
-                                cache_account_email(&dir, &active_name, email);
-                            }
-                            if let Some(plan) = me.get("plan").and_then(|v| v.as_str()) {
-                                println!("  Plan: {plan}");
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            401 | 403 => {
-                println!("  Status: Session revoked");
-                println!();
-                println!("  Your session has been revoked (possibly from the web dashboard).");
-                println!("  Run `mentedb-mcp login` to create a new session.");
-                // Remove only the stale account, preserving the others.
-                remove_account_silent(&dir, &active_name);
-            }
-            code => {
-                println!("  Status: Error (HTTP {code})");
-                println!("  The cloud service may be temporarily unavailable.");
-            }
-        },
-        Err(e) => {
-            if e.is_timeout() {
-                println!("  Status: Timeout");
-                println!("  Could not reach {api_url} within 10 seconds.");
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|info| info.get("port").and_then(|p| p.as_u64()))
+        .and_then(|p| u16::try_from(p).ok());
+    match daemon_port {
+        Some(port) => {
+            let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+            if std::net::TcpStream::connect_timeout(&addr, DAEMON_CONNECT_TIMEOUT).is_ok() {
+                println!("  Daemon:     running (port {port})");
             } else {
-                println!("  Status: Connection failed");
-                println!("  Error: {e}");
+                println!("  Daemon:     not running (stale daemon.json, port {port})");
             }
         }
+        None => println!("  Daemon:     not started"),
     }
 
-    Ok(())
+    // Cloud reachability: unauthenticated GET /health on the configured base
+    // URL. Answers "is the service up", not "is the token valid"; the auth
+    // line above covers token validity from local state.
+    if config::credentials_path(data_dir).exists() {
+        let api_url = std::env::var("MENTEDB_API_URL")
+            .ok()
+            .or_else(|| {
+                config::load_accounts(data_dir)
+                    .ok()
+                    .and_then(|c| c.active_account().and_then(|(_, a)| a.cloud_url.clone()))
+            })
+            .unwrap_or_else(|| config::DEFAULT_CLOUD_URL.to_string());
+        let reachable = reqwest::Client::new()
+            .get(format!("{api_url}/health"))
+            .timeout(CLOUD_HEALTH_TIMEOUT)
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false);
+        if reachable {
+            println!("  Cloud:      reachable ({api_url})");
+        } else {
+            println!("  Cloud:      unreachable ({api_url})");
+        }
+    } else {
+        println!("  Cloud:      not configured (local mode)");
+    }
+
+    match sync_report(data_dir) {
+        SyncReport::LastSuccess(ts) => println!("  Sync:       last successful sync {ts}"),
+        SyncReport::FailingSince(ts) => println!("  Sync:       failing since {ts}"),
+        SyncReport::NoEvents => println!("  Sync:       no sync events logged yet"),
+    }
+
+    println!();
+    let healthy = depth < hook::SPOOL_WARN_THRESHOLD && auth_ok;
+    if healthy {
+        println!("  Health:     ok");
+        Ok(())
+    } else {
+        let mut reasons: Vec<String> = Vec::new();
+        if depth >= hook::SPOOL_WARN_THRESHOLD {
+            reasons.push(format!("spool backlog {depth}"));
+        }
+        if !auth_ok {
+            reasons.push("auth error".to_string());
+        }
+        println!("  Health:     degraded ({})", reasons.join(", "));
+        std::process::exit(1);
+    }
+}
+
+/// Sync recency derived from the newest daily hook log file.
+#[derive(Debug, PartialEq)]
+enum SyncReport {
+    /// Newest sync event is a full spool flush at this timestamp.
+    LastSuccess(String),
+    /// Newest sync event is a store failure at this timestamp.
+    FailingSince(String),
+    /// No hook log or no sync events in it yet.
+    NoEvents,
+}
+
+/// Marker lines written by the hook logger (see flush_spool and the
+/// PostToolUse handler in src/hook/mod.rs). Matched by substring so the
+/// structured fields around them do not matter.
+const SYNC_OK_MARKER: &str = "offline spool fully flushed";
+const SYNC_FAIL_MARKER: &str = "store_note failed";
+
+fn sync_report(data_dir: &std::path::Path) -> SyncReport {
+    // tracing_appender writes daily files named mentedb-hook.log.YYYY-MM-DD;
+    // the date suffix sorts lexically, so max by path is the newest file.
+    let newest_log = std::fs::read_dir(data_dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("mentedb-hook.log."))
+        })
+        .max();
+    let Some(path) = newest_log else {
+        return SyncReport::NoEvents;
+    };
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return SyncReport::NoEvents;
+    };
+    // Lines are appended chronologically, so the last hit of each marker is
+    // the newest, and its leading token is the tracing timestamp.
+    let newest_ts = |marker: &str| -> Option<String> {
+        raw.lines()
+            .rev()
+            .find(|l| l.contains(marker))
+            .and_then(|l| l.split_whitespace().next())
+            .map(str::to_string)
+    };
+    match (newest_ts(SYNC_OK_MARKER), newest_ts(SYNC_FAIL_MARKER)) {
+        // ISO-8601 timestamps compare chronologically as strings.
+        (Some(ok), Some(fail)) if fail > ok => SyncReport::FailingSince(fail),
+        (Some(ok), _) => SyncReport::LastSuccess(ok),
+        (None, Some(fail)) => SyncReport::FailingSince(fail),
+        (None, None) => SyncReport::NoEvents,
+    }
 }
 
 /// Directory holding MenteDB credentials and state (`~/.mentedb`).
@@ -1808,4 +1832,62 @@ fn setup_cursor(home: &str, binary: &str, force: bool) -> anyhow::Result<()> {
     println!("\nDone! Restart Cursor to activate MenteDB memory.");
     println!("\nTo sync memories across devices, run: mentedb-mcp login");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_report_no_events_without_logs() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(sync_report(dir.path()), SyncReport::NoEvents);
+        // A log with neither marker also reports no events.
+        std::fs::write(
+            dir.path().join("mentedb-hook.log.2026-07-22"),
+            "2026-07-22T09:00:00.000000Z  INFO hook started\n",
+        )
+        .unwrap();
+        assert_eq!(sync_report(dir.path()), SyncReport::NoEvents);
+    }
+
+    #[test]
+    fn sync_report_success_when_flush_is_newest() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("mentedb-hook.log.2026-07-22"),
+            concat!(
+                "2026-07-22T09:00:00.000000Z  WARN store_note failed, spooling for retry\n",
+                "2026-07-22T11:00:00.000000Z  INFO offline spool fully flushed\n",
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            sync_report(dir.path()),
+            SyncReport::LastSuccess("2026-07-22T11:00:00.000000Z".to_string())
+        );
+    }
+
+    #[test]
+    fn sync_report_reads_newest_log_and_reports_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        // An older file reports success; only the newest file may be read.
+        std::fs::write(
+            dir.path().join("mentedb-hook.log.2026-07-20"),
+            "2026-07-20T10:00:00.000000Z  INFO offline spool fully flushed\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("mentedb-hook.log.2026-07-22"),
+            concat!(
+                "2026-07-22T09:00:00.000000Z  INFO offline spool fully flushed\n",
+                "2026-07-22T11:00:00.000000Z  WARN store_note failed, spooling for retry\n",
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            sync_report(dir.path()),
+            SyncReport::FailingSince("2026-07-22T11:00:00.000000Z".to_string())
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Store less, store better: the PostToolUse dedupe becomes an 8-entry rolling hash window, low-information commands (fmt, lint, build) are never stored, and sub-12-char acknowledgement prompts no longer produce junk turn memories
- Show-why on injected context: recalled memory lines carry a compact provenance suffix (project, reason, score) when the server provides those fields, byte-identical output when it does not
- `mentedb-mcp status` now prints a compact local health block (data dir, spool, auth, daemon, cloud, sync recency) and exits 1 when unhealthy so it can be scripted

## Changes

- `src/hook/mod.rs`: `SessionState.last_note` replaced by `recent_note_hashes` with `note_seen_recently` (window `NOTE_DEDUPE_WINDOW = 8`); new `LOW_INFO_BASH` prefix list beside `READ_ONLY_BASH` (git state reads were already covered there); Stop path gates turn storage on `worth_storing_turn` (`MIN_STORED_PROMPT_CHARS = 12`) and keeps short acknowledgements out of `last_user_message` so recall blending stays grounded; `provenance_suffix` renders the show-why bracket in `format_context`; `SPOOL_WARN_THRESHOLD` promoted to module scope so status and the in-session warning agree
- `src/main.rs`: `run_status` reworked from a token-authenticated cloud check into the local health block: spool depth via `spool::depth`, `auth_error` marker, daemon liveness via TCP connect to the `daemon.json` port (parsed directly so cloud-only builds work), unauthenticated GET `/health` on the configured base URL with a 3s timeout, and sync recency from the newest `mentedb-hook.log.*` file (newest "offline spool fully flushed" vs newest "store_note failed"); exit code 0 when healthy (spool below 10, no auth error), 1 otherwise; the two helpers only the old status used (`cache_account_email`, `remove_account_silent`) are removed

## Verification

- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo build`, `cargo test`: all clean, 51 tests pass
- New unit tests: note-window dedupe (repeat within window suppressed, eviction re-stores), low-information command matcher (skips fmt/clippy/build/lint/prettier/eslint, keeps test/install/commit), min-length gate boundaries, provenance suffix partial and absent fields, `sync_report` (no events, success newest, failure newest, newest log file wins)
- Smoke-tested the built binary against temp data dirs: healthy block exits 0; auth_error plus 12 spooled entries plus stale daemon.json reports degraded and exits 1; unreachable cloud URL renders unreachable and does not affect the exit code

## Notes

- A `status` subcommand already existed (authenticated cloud connection check); it is replaced by the local-state health block per this spec. Deep cloud auth diagnosis still lives in `mentedb-mcp doctor`, which covers what the old status did and more
- The show-why suffix renders project, reason, and score; `memory_type` already leads each line as `[semantic]` etc., so it is not repeated in the suffix
