### PR TITLE
feat: PreToolUse hook surfaces action rules before commits and PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0627d11f77f3283e1d02ae8dcb9b78e879e2eba96e0f7f52820596de6cce9d"
+checksum = "2855fae5df09e36fa88ead4d45d7f2c717a4b4dd45e806dc9f9ee0e2189db9ee"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-consolidation",
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-cognitive"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9b90a1a82715eef1db3c6baba57338ed369fad1aae8e738ae870d42cd2f6ab"
+checksum = "b45549395473a1ebc657f1e6c7dba4ce2a7e119a245ad997a0f8b8c47ed2db53"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1703,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-consolidation"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3380bb4b1baecf16ecbfc68c5ab824e82c0682183bb5353537d3b47f8ad0149d"
+checksum = "f67033cacb2e413bf34038441f465bad654761eae2339f739f07b46e7853403f"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1716,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-context"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bfeba43e88fd77d8a4d057a3e2adde77baf182ad2044559f6a9f771ac72b78"
+checksum = "aa830446a4a0f573e12e530d193c3ee7e610861d2a12c7b395eae0f1ca73a9c5"
 dependencies = [
  "ahash",
  "mentedb-core",
@@ -1730,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-core"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f12569189e02071010810a27f92cc149dad65214f85f08f1e18a9d71aec509"
+checksum = "c3666ab2503dbd5cac70ec2a24378aebd8e506f69756e8a325c884ac3842bc81"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-embedding"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7f90a3fefce4f8599745e97190853db039d439533741ff3c56d816cc780c7c"
+checksum = "da2c422e28b26ecc4c19c6e6a4aeae6745c840362054c14b8423ed78663716dd"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1766,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-extraction"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a1c6cbda06f758f995825eab4f0a306216e285b685d17a12ba64fb8e550a8b"
+checksum = "368504afef5efe9357d3aad79585339d8133f05053974cfaac3ef4926b014bbb"
 dependencies = [
  "mentedb-cognitive",
  "mentedb-core",
@@ -1784,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-graph"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7a5c6ccd903c00fe70930b5d1292a4b8cbaffb452d179fbecb2412befa7757"
+checksum = "db0f910f9f24256fb453330dc7d225cf53329407abc81a9e524fb4f7e78801d3"
 dependencies = [
  "ahash",
  "bincode",
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-index"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b4905a933940f48a1a624938a864b4214b43a2f99adb7bb65afde630026e77"
+checksum = "d17c9804b0b80f6882f56c4906bbff654fe0c8b7219aa0c9302d9dd1b5711317"
 dependencies = [
  "ahash",
  "bincode",
@@ -1851,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-query"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a5cafafd5933ad904833d3f3a3dac9565a0868137e550509152e7955ca0e2c"
+checksum = "668bb850fdfbb20f14cb6395c700a4244def408c0df7984003a6a45f256c2fd4"
 dependencies = [
  "mentedb-core",
  "serde",
@@ -1864,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "mentedb-storage"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a168d038363362a84d1964600eea64713397bc9f5a5e345a5c0f42e47c7737e7"
+checksum = "e620b1cc5b8345cd6aecb9d0e21af60807b12b62c0013a0c1d966730b75eea31"
 dependencies = [
  "ahash",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,14 @@ open = "5"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 
 # Local mode dependencies (heavy - embedded DB, embeddings, LLM extraction)
-mentedb = { version = "0.26", features = ["enrichment"], optional = true }
-mentedb-core = { version = "0.26", optional = true }
-mentedb-graph = { version = "0.26", optional = true }
-mentedb-cognitive = { version = "0.26", optional = true }
-mentedb-context = { version = "0.26", optional = true }
-mentedb-embedding = { version = "0.26", features = ["local"], optional = true }
-mentedb-extraction = { version = "0.26", optional = true }
-mentedb-consolidation = { version = "0.26", optional = true }
+mentedb = { version = "0.27.2", features = ["enrichment"], optional = true }
+mentedb-core = { version = "0.27.2", optional = true }
+mentedb-graph = { version = "0.27.2", optional = true }
+mentedb-cognitive = { version = "0.27.2", optional = true }
+mentedb-context = { version = "0.27.2", optional = true }
+mentedb-embedding = { version = "0.27.2", features = ["local"], optional = true }
+mentedb-extraction = { version = "0.27.2", optional = true }
+mentedb-consolidation = { version = "0.27.2", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ For Claude Code (the CLI), MenteDB integrates through lifecycle hooks rather tha
 npx mentedb-mcp@latest setup claude-code
 ```
 
-This writes three hooks into `~/.claude/settings.json`:
+This writes six hooks into `~/.claude/settings.json`:
 
 | Hook | What it does |
 |------|-------------|
 | `UserPromptSubmit` | Recalls context for your prompt and injects it before the model responds |
 | `PostToolUse` | Captures significant actions (file edits, non-trivial commands) as they happen, so a long agentic session never loses work if it is interrupted |
+| `PreToolUse` | Surfaces your action rules (memories tagged `trigger:git-commit`, `trigger:pr-create`) right before the matching command runs, so commit style and PR format preferences apply at the exact moment they matter |
 | `Stop` | Stores the completed turn (your prompt plus the assistant's answer) through the full cognitive pipeline |
 | `PreCompact` | Flushes memory to disk before Claude Code compacts a long session, so nothing captured so far is lost |
 | `SessionStart` | Injects your user profile and always-scoped memories at session start, resume, and right after context compaction |
@@ -103,7 +104,7 @@ The `update` command shows you the exact instructions that will be written and a
 | `login` | Authenticate with MenteDB Cloud via browser |
 | `logout` | Remove cloud credentials |
 | `status` | Check cloud connection and token validity |
-| `hook <event>` | Process a lifecycle hook: user-prompt, stop, session-start, post-tool-use, or pre-compact (reads JSON from stdin) |
+| `hook <event>` | Process a lifecycle hook: user-prompt, stop, session-start, post-tool-use, pre-tool-use, pre-compact |
 | `daemon` | Run the local hook daemon (started automatically by hooks when needed) |
 
 ## Authentication

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -199,6 +199,46 @@ struct InjectionContextRequest {
     max_episodic: Option<usize>,
 }
 
+#[derive(Deserialize)]
+struct ActionRulesRequest {
+    trigger: String,
+    #[serde(default)]
+    k: Option<usize>,
+}
+
+/// Standing rules for a class of agent actions (memories tagged
+/// `trigger:<action>`), for the pre-tool hook. Read only, no embedding, no
+/// LLM: a tag-index recall so it stays well inside the hook's time budget.
+async fn action_rules(
+    State(state): State<DaemonState>,
+    headers: HeaderMap,
+    Json(req): Json<ActionRulesRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !authorized(&state, &headers) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    let db = state.server.db_ref();
+    // Local single-user connector: no per-agent or per-user isolation,
+    // mirror the injection-context route's global owner scope.
+    let rules = db
+        .recall_for_action(&req.trigger, None, None, req.k.unwrap_or(6).min(12))
+        .map_err(|e| {
+            tracing::error!(error = %e, "action rules recall failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    let items: Vec<serde_json::Value> = rules
+        .iter()
+        .map(|n| {
+            json!({
+                "id": n.id.to_string(),
+                "content": n.content,
+                "created_at": n.created_at,
+            })
+        })
+        .collect();
+    Ok(Json(json!({ "rules": items })))
+}
+
 /// Injection-ready context through the engine's attention policy.
 async fn injection_context(
     State(state): State<DaemonState>,
@@ -388,6 +428,7 @@ pub async fn run(config: ServerConfig) -> anyhow::Result<()> {
         .route("/v1/export", post(export))
         .route("/v1/injection-context", post(injection_context))
         .route("/v1/injection-outcome", post(injection_outcome))
+        .route("/v1/action-rules", post(action_rules))
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;

--- a/src/hook/backend.rs
+++ b/src/hook/backend.rs
@@ -121,6 +121,56 @@ impl Backend {
         }
     }
 
+    /// Standing rules for the action the agent is about to take (memories
+    /// tagged `trigger:<action>`), newest first. Best-effort: any failure,
+    /// including an older gateway or daemon that does not know the call,
+    /// returns an empty vec so the hook stays silent and the user's tool
+    /// call is never delayed or blocked.
+    pub async fn action_rules(&self, trigger: &str, k: usize) -> Vec<String> {
+        fn contents(rules: Option<&serde_json::Value>) -> Vec<String> {
+            rules
+                .and_then(|r| r.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|r| r.get("content").and_then(|c| c.as_str()))
+                        .map(|s| s.to_string())
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+        match self {
+            Backend::Cloud(client) => {
+                let Ok(resp) = client
+                    .call_tool("get_action_rules", json!({ "trigger": trigger, "k": k }))
+                    .await
+                else {
+                    return Vec::new();
+                };
+                if resp.is_error {
+                    // Older gateway: unknown tool comes back as a tool error.
+                    return Vec::new();
+                }
+                let Some(text) = resp.content.first().map(|c| c.text.clone()) else {
+                    return Vec::new();
+                };
+                let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) else {
+                    return Vec::new();
+                };
+                contents(parsed.get("rules"))
+            }
+            #[cfg(feature = "local")]
+            Backend::Local(client) => {
+                let Ok(v) = client
+                    .post("/v1/action-rules", json!({ "trigger": trigger, "k": k }))
+                    .await
+                else {
+                    return Vec::new();
+                };
+                contents(v.get("rules"))
+            }
+        }
+    }
+
     /// Close the attention loop: report which injected memories the reply
     /// drew on. Best-effort; older backends simply ignore it.
     pub async fn record_injection_outcome(&self, shown_ids: &[String], assistant_text: &str) {

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -36,8 +36,131 @@ pub enum HookEvent {
     SessionStart,
     /// PostToolUse: capture a significant tool action live
     PostToolUse,
+    /// PreToolUse: surface action rules right before a matching tool call
+    PreToolUse,
     /// PreCompact: flush memory before context is compacted away
     PreCompact,
+}
+
+/// Total budget for resolving the backend and fetching action rules inside
+/// the PreToolUse hook. The hook sits directly in front of the user's tool
+/// call, so it must be fast and fail open: on timeout the rules are simply
+/// skipped for this call and the command runs untouched.
+const ACTION_RULES_BUDGET_MS: u64 = 1500;
+
+/// Rules requested per action; mirrors the server side default and keeps the
+/// injected block small.
+const ACTION_RULES_MAX: usize = 6;
+
+/// Split a shell command into segments at unquoted `&&`, `||`, `;`, `|` and
+/// newlines, so each simple command can be inspected on its own. Quoted
+/// operators stay inside their segment, which keeps `git commit -m "a && b"`
+/// as one command and keeps `echo "git commit"` from ever parsing as git.
+fn split_shell_segments(command: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut chars = command.chars().peekable();
+    let mut in_single = false;
+    let mut in_double = false;
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' if !in_double => {
+                in_single = !in_single;
+                current.push(c);
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                current.push(c);
+            }
+            '\\' if !in_single => {
+                current.push(c);
+                if let Some(n) = chars.next() {
+                    current.push(n);
+                }
+            }
+            '&' | '|' | ';' | '\n' if !in_single && !in_double => {
+                if (c == '&' || c == '|') && chars.peek() == Some(&c) {
+                    chars.next();
+                }
+                segments.push(std::mem::take(&mut current));
+            }
+            _ => current.push(c),
+        }
+    }
+    segments.push(current);
+    segments
+}
+
+/// Leading `FOO=bar` style environment assignments before the program name.
+fn is_env_assignment(token: &str) -> bool {
+    !token.starts_with('-') && !token.starts_with('=') && token.contains('=')
+}
+
+/// The real git subcommand, skipping global flags. Value-consuming globals
+/// (`-c name=value`, `-C path`, and friends) skip their argument too, so
+/// `git -c commit.gpgsign=false commit` resolves to `commit` while
+/// `git config commit.gpgsign false` resolves to `config`.
+fn git_subcommand<'a>(tokens: &[&'a str]) -> Option<&'a str> {
+    const VALUE_FLAGS: [&str; 7] = [
+        "-c",
+        "-C",
+        "--git-dir",
+        "--work-tree",
+        "--namespace",
+        "--exec-path",
+        "--config-env",
+    ];
+    let mut i = 0;
+    while i < tokens.len() {
+        let t = tokens[i];
+        if t.starts_with('-') {
+            if VALUE_FLAGS.contains(&t) {
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        return Some(t);
+    }
+    None
+}
+
+/// Map a Bash command line to an action trigger, or None when no rule class
+/// applies. First match wins across compound segments.
+fn action_trigger_for_command(command: &str) -> Option<&'static str> {
+    for segment in split_shell_segments(command) {
+        let tokens: Vec<&str> = segment.split_whitespace().collect();
+        let mut i = 0;
+        while i < tokens.len() && is_env_assignment(tokens[i]) {
+            i += 1;
+        }
+        let Some(&prog) = tokens.get(i) else { continue };
+        let prog_name = prog.rsplit('/').next().unwrap_or(prog);
+        match prog_name {
+            "git" => {
+                if let Some(sub) = git_subcommand(&tokens[i + 1..])
+                    && sub == "commit"
+                {
+                    return Some("git-commit");
+                }
+            }
+            "gh" if tokens.get(i + 1) == Some(&"pr") && tokens.get(i + 2) == Some(&"create") => {
+                return Some("pr-create");
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Human label for a trigger, used in the injected header line.
+fn trigger_label(trigger: &str) -> &'static str {
+    match trigger {
+        "git-commit" => "the git commit you are about to run",
+        "pr-create" => "the pull request you are about to create",
+        _ => "the action you are about to take",
+    }
 }
 
 /// Per-session state persisted across hook invocations.
@@ -390,6 +513,66 @@ async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyh
                     &json!({ "kind": "note", "content": note, "project": project }),
                 );
             }
+        }
+        HookEvent::PreToolUse => {
+            // Action-cued rules: right before a matching tool call, fetch the
+            // standing rules for that class of action (tagged
+            // trigger:<action>) and inject them as context. This is the only
+            // moment a commit style preference is relevant, and the one
+            // moment topic similarity cannot find it.
+            //
+            // Safety contract: never emit a permissionDecision (the hook must
+            // not auto-approve or block anything), stay inside a hard time
+            // budget, and on any failure print nothing and exit 0 so the
+            // user's command is never delayed or broken by memory being down.
+            let tool = payload
+                .get("tool_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if tool != "Bash" {
+                return Ok(());
+            }
+            let command = payload
+                .pointer("/tool_input/command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let Some(trigger) = action_trigger_for_command(command) else {
+                return Ok(());
+            };
+
+            let fetch = async {
+                let backend = Backend::resolve(data_dir, force_local).await.ok()?;
+                Some(backend.action_rules(trigger, ACTION_RULES_MAX).await)
+            };
+            let rules = tokio::time::timeout(
+                std::time::Duration::from_millis(ACTION_RULES_BUDGET_MS),
+                fetch,
+            )
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+            if rules.is_empty() {
+                return Ok(());
+            }
+
+            let mut text = format!(
+                "MenteDB action rules for {} (newest first; when two rules conflict, follow the newest):",
+                trigger_label(trigger)
+            );
+            for r in &rules {
+                text.push_str("\n- ");
+                text.push_str(r);
+            }
+            println!(
+                "{}",
+                json!({
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "additionalContext": text,
+                    }
+                })
+            );
         }
         HookEvent::PreCompact => {
             // The injection ledger mirrors what is in the model's context;
@@ -994,6 +1177,92 @@ fn format_session_context(ctx: &serde_json::Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn action_trigger_fires_on_real_commit_shapes() {
+        // The exact command shapes agents actually run, including global
+        // flags whose values contain the word commit.
+        for cmd in [
+            "git commit -m \"fix: something\"",
+            "git -c commit.gpgsign=false commit -q -m \"x\"",
+            "git commit --amend --no-edit",
+            "cd /tmp/repo && git commit -m 'y'",
+            "git add -A && git -c commit.gpgsign=false commit -m \"z\" && git log -1",
+            "FOO=bar git commit -m x",
+            "/usr/bin/git commit -m x",
+            "git -C /tmp/repo commit -m x",
+            "git commit -m \"quoted && operator inside\"",
+        ] {
+            assert_eq!(
+                action_trigger_for_command(cmd),
+                Some("git-commit"),
+                "should fire: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn action_trigger_never_fires_on_lookalikes() {
+        // False triggers are the failure mode that erodes trust: none of
+        // these is a commit.
+        for cmd in [
+            "git log --oneline -5",
+            "git config commit.gpgsign false",
+            "git config --get commit.template",
+            "echo \"git commit\"",
+            "echo 'run git commit later'",
+            "git log | grep commit",
+            "git status",
+            "git show HEAD --stat",
+            "grep -rn \"git commit\" docs/",
+            "cargo test commit_parser",
+            "git push origin main",
+            "gh pr view 42",
+            "gh pr merge 42",
+        ] {
+            assert_eq!(
+                action_trigger_for_command(cmd),
+                None,
+                "must not fire: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn action_trigger_pr_create() {
+        assert_eq!(
+            action_trigger_for_command("gh pr create --title x --body y"),
+            Some("pr-create")
+        );
+        assert_eq!(
+            action_trigger_for_command("git push -u origin b && gh pr create --fill"),
+            Some("pr-create")
+        );
+        assert_eq!(
+            action_trigger_for_command("gh pr create"),
+            Some("pr-create")
+        );
+    }
+
+    #[test]
+    fn action_trigger_first_match_wins_and_empty_safe() {
+        // A commit in the same compound command leads.
+        assert_eq!(
+            action_trigger_for_command("git commit -m x && gh pr create --fill"),
+            Some("git-commit")
+        );
+        assert_eq!(action_trigger_for_command(""), None);
+        assert_eq!(action_trigger_for_command("   "), None);
+    }
+
+    #[test]
+    fn shell_segments_respect_quotes() {
+        let segs = split_shell_segments("git commit -m \"a && b\" && git push");
+        assert_eq!(segs.len(), 2);
+        assert!(segs[0].contains("a && b"));
+        let segs = split_shell_segments("echo 'x; y' ; git commit");
+        assert_eq!(segs.len(), 2);
+    }
 
     #[test]
     fn format_context_renders_memories_and_pain() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1113,6 +1113,7 @@ async fn run_doctor(data_dir: &std::path::Path) -> anyhow::Result<()> {
         "Stop",
         "SessionStart",
         "PostToolUse",
+        "PreToolUse",
         "PreCompact",
     ];
     for dir in claude_config_dirs(&home) {
@@ -1398,6 +1399,7 @@ fn setup_claude_code(home: &str, binary: &str, force: bool) -> anyhow::Result<()
     println!("\nDone. MenteDB now runs on every Claude Code turn via hooks:");
     println!("  UserPromptSubmit  recalls context for the prompt");
     println!("  PostToolUse       captures significant actions as they happen");
+    println!("  PreToolUse        surfaces action rules before git commits and PRs");
     println!("  Stop              stores the completed turn");
     println!("  PreCompact        flushes memory before context is compacted");
     println!("  SessionStart      injects your profile and standing rules");
@@ -1428,19 +1430,31 @@ fn install_claude_code_hooks(
         *hooks = serde_json::json!({});
     }
 
-    let events: [(&str, &str, &str); 5] = [
-        ("UserPromptSubmit", "user-prompt", ""),
-        ("Stop", "stop", ""),
-        ("SessionStart", "session-start", "startup|resume|compact"),
+    // (event, subcommand, matcher, timeout seconds). The timeout matters for
+    // PreToolUse: it runs directly in front of the user's tool call and the
+    // client's default hook timeout is far too long to risk there; 5 seconds
+    // caps the worst case while the hook's internal budget keeps the normal
+    // case near-instant and fail-open.
+    let events: [(&str, &str, &str, Option<u64>); 6] = [
+        ("UserPromptSubmit", "user-prompt", "", None),
+        ("Stop", "stop", "", None),
+        (
+            "SessionStart",
+            "session-start",
+            "startup|resume|compact",
+            None,
+        ),
         (
             "PostToolUse",
             "post-tool-use",
             "Write|Edit|MultiEdit|NotebookEdit|Bash",
+            None,
         ),
-        ("PreCompact", "pre-compact", ""),
+        ("PreToolUse", "pre-tool-use", "Bash", Some(5)),
+        ("PreCompact", "pre-compact", "", None),
     ];
 
-    for (event, subcommand, matcher) in events {
+    for (event, subcommand, matcher, timeout) in events {
         let command = format!("{hook_command} {subcommand}");
         let entries = hooks
             .as_object_mut()
@@ -1477,9 +1491,11 @@ fn install_claude_code_hooks(
             });
         }
 
-        let mut group = serde_json::json!({
-            "hooks": [ { "type": "command", "command": command } ]
-        });
+        let mut hook_entry = serde_json::json!({ "type": "command", "command": command });
+        if let Some(secs) = timeout {
+            hook_entry["timeout"] = serde_json::json!(secs);
+        }
+        let mut group = serde_json::json!({ "hooks": [hook_entry] });
         if !matcher.is_empty() {
             group["matcher"] = serde_json::json!(matcher);
         }

--- a/src/tools/handler.rs
+++ b/src/tools/handler.rs
@@ -12,6 +12,7 @@ impl ServerHandler for MenteDbServer {
              4. forget_memory — Delete a memory when the user asks to forget.\n\
              \n\
              SCOPE: Set scope: 'always' for hard rules/constraints the user wants enforced every turn. Default 'contextual' is retrieved by similarity.\n\
+             ACTION RULES: when the user states a rule about HOW to perform a class of action (commit message style, PR format, push policy), tag it trigger:<action> in lowercase kebab case: trigger:git-commit, trigger:pr-create, trigger:git-push. These surface automatically right before that action runs, so do NOT also mark them scope: 'always'.\n\
              TYPES: semantic (facts/preferences), procedural (how-to), correction (was wrong now right), anti_pattern (never do X), episodic (what happened), reasoning (why a decision was made).\n\
              QUALITY: One fact per memory. Self-contained. Include project context. Under 200 words. Don't store chitchat, temp info, or large code blocks.\n\
              USE THE CONTEXT: process_turn returns summaries with IDs. Reference them. Call search_memories(id) for full text.\n\

--- a/src/tools/memory.rs
+++ b/src/tools/memory.rs
@@ -3,7 +3,7 @@ use super::*;
 #[rmcp::tool_router(router = tool_router_memory, vis = "pub")]
 impl MenteDbServer {
     #[rmcp::tool(
-        description = "Store an important fact, preference, decision, or correction. Use types: semantic (facts), procedural (how-to), correction (fixes), anti_pattern (mistakes to avoid). Add tags for retrieval."
+        description = "Store an important fact, preference, decision, or correction. Use types: semantic (facts), procedural (how-to), correction (fixes), anti_pattern (mistakes to avoid). Add tags for retrieval. For rules about HOW to perform an action (commit style, PR format), add a trigger:<action> tag (trigger:git-commit, trigger:pr-create) so the rule surfaces right before that action runs."
     )]
     async fn store_memory(
         &self,

--- a/tests/hook_e2e.rs
+++ b/tests/hook_e2e.rs
@@ -387,3 +387,141 @@ fn hook_tolerates_garbage_input() {
     assert!(output.status.success());
     assert!(output.stdout.is_empty());
 }
+
+#[test]
+fn pre_tool_use_injects_action_rules_before_commit() {
+    use mentedb::prelude::*;
+    use mentedb_core::types::AgentId;
+
+    let dir = tempfile::tempdir().unwrap();
+
+    // Seed action rules directly in the engine, then close it so the daemon
+    // (single writer) can open the same directory.
+    {
+        let db = mentedb::MenteDb::open(dir.path()).unwrap();
+        let mut commit_rule = MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::Procedural,
+            "never add Co-Authored-By trailers to commits".to_string(),
+            vec![],
+        );
+        commit_rule.tags = vec!["trigger:git-commit".to_string()];
+        db.store(commit_rule).unwrap();
+
+        let mut pr_rule = MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::Procedural,
+            "PR descriptions use Summary and Verification sections".to_string(),
+            vec![],
+        );
+        pr_rule.tags = vec!["trigger:pr-create".to_string()];
+        db.store(pr_rule).unwrap();
+
+        let ordinary = MemoryNode::new(
+            AgentId::nil(),
+            MemoryType::Semantic,
+            "the user prefers dark mode".to_string(),
+            vec![],
+        );
+        db.store(ordinary).unwrap();
+        // Persist the indexes (the tag bitmap is written by close, not drop)
+        // so the daemon reopening this directory sees the trigger index.
+        db.close().unwrap();
+    }
+
+    let _guard = spawn_daemon(dir.path());
+    wait_for_daemon(dir.path(), Duration::from_secs(120));
+
+    // The exact command shape agents run, global flag value containing the
+    // word commit included.
+    let out = run_hook(
+        dir.path(),
+        "pre-tool-use",
+        &serde_json::json!({
+            "session_id": "sess-pre",
+            "tool_name": "Bash",
+            "tool_input": { "command": "git -c commit.gpgsign=false commit -m \"fix: x\"" },
+            "cwd": "/tmp/myproj",
+            "hook_event_name": "PreToolUse",
+        }),
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(out.trim()).expect("pre-tool-use must print valid JSON");
+    let hso = &parsed["hookSpecificOutput"];
+    assert_eq!(hso["hookEventName"], "PreToolUse");
+    let ctx = hso["additionalContext"].as_str().unwrap_or_default();
+    assert!(
+        ctx.contains("never add Co-Authored-By trailers"),
+        "commit rule must be injected, got: {ctx}"
+    );
+    assert!(
+        !ctx.contains("Summary and Verification"),
+        "pr-create rule must not fire on a commit, got: {ctx}"
+    );
+    assert!(
+        !ctx.contains("dark mode"),
+        "ordinary memories must not enter the action channel, got: {ctx}"
+    );
+    assert!(
+        hso.get("permissionDecision").is_none(),
+        "the hook must never emit a permission decision"
+    );
+
+    // Non-commit git commands stay silent.
+    let out = run_hook(
+        dir.path(),
+        "pre-tool-use",
+        &serde_json::json!({
+            "session_id": "sess-pre",
+            "tool_name": "Bash",
+            "tool_input": { "command": "git log --oneline -3" },
+            "hook_event_name": "PreToolUse",
+        }),
+    );
+    assert!(
+        out.trim().is_empty(),
+        "git log must not trigger rules: {out}"
+    );
+
+    // Non-Bash tools stay silent even if their input mentions git.
+    let out = run_hook(
+        dir.path(),
+        "pre-tool-use",
+        &serde_json::json!({
+            "session_id": "sess-pre",
+            "tool_name": "Edit",
+            "tool_input": { "file_path": "git_commit.rs" },
+            "hook_event_name": "PreToolUse",
+        }),
+    );
+    assert!(out.trim().is_empty(), "non-Bash tools are ignored: {out}");
+}
+
+#[test]
+fn pre_tool_use_is_silent_with_no_rules_and_tolerates_garbage() {
+    let dir = tempfile::tempdir().unwrap();
+    let _guard = spawn_daemon(dir.path());
+    wait_for_daemon(dir.path(), Duration::from_secs(120));
+
+    // A commit with zero stored rules injects nothing.
+    let out = run_hook(
+        dir.path(),
+        "pre-tool-use",
+        &serde_json::json!({
+            "session_id": "sess-empty",
+            "tool_name": "Bash",
+            "tool_input": { "command": "git commit -m x" },
+            "hook_event_name": "PreToolUse",
+        }),
+    );
+    assert!(out.trim().is_empty(), "no rules means no output: {out}");
+
+    // Garbage stdin never breaks the tool call: exit 0, no output. run_hook
+    // asserts the exit status itself.
+    let out = run_hook(
+        dir.path(),
+        "pre-tool-use",
+        &serde_json::json!("not an object"),
+    );
+    assert!(out.trim().is_empty());
+}


### PR DESCRIPTION
## Summary
- Sixth lifecycle hook: PreToolUse (matcher Bash, settings timeout 5s) fetches memories tagged `trigger:git-commit` / `trigger:pr-create` right before the matching command and injects them as `additionalContext`.
- New `Backend::action_rules` (cloud: `get_action_rules` tool with older-gateway degradation to silence; local: new `/v1/action-rules` daemon route calling engine `recall_for_action`).
- Installer, doctor, setup summary, README, and tool instructions updated; store_memory description teaches the trigger tag convention.
- Engine crates bumped to 0.27.2 (all eight together; mixed versions split the type graph).

## Safety contract
- Never emits a permissionDecision (no auto-approve, no blocking).
- 1.5s internal budget inside a 5s settings timeout; any failure means no output and exit 0, the user's command always runs untouched.
- Command matching is a parser, not a grep: git global value flags (`-c k=v`, `-C path`), compound segments, env prefixes, and quoted text are handled, with a unit test per shape.

## Verification
- cargo fmt, clippy -D warnings clean on default and local features.
- 58 tests green, including live e2e: a seeded engine behind a real daemon, the real hook binary injecting the commit rule for `git -c commit.gpgsign=false commit`, staying silent on git log, non-Bash tools, an empty database, and garbage stdin, and never emitting a permission decision.