### PR TITLE
Claude plugin: marketplace installable memory

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "mentedb",
+  "owner": { "name": "MenteDB", "url": "https://mentedb.com" },
+  "plugins": [
+    {
+      "name": "mentedb",
+      "source": "./plugin",
+      "description": "Persistent memory for Claude: recall before answering, capture after, contradictions detected, survives compaction."
+    }
+  ]
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "mentedb",
+  "description": "Persistent memory for Claude: recalls what matters before answering, stores what it learns after, detects contradictions, and survives compaction. Works in Claude Code today with deterministic lifecycle hooks; in Cowork the bundled memory skill drives recall and capture until per turn hook events are enabled there.",
+  "version": "0.1.0",
+  "author": { "name": "MenteDB", "url": "https://mentedb.com" },
+  "homepage": "https://mentedb.com/docs",
+  "repository": "https://github.com/nambok/mentedb-mcp",
+  "license": "Apache-2.0",
+  "keywords": ["memory", "recall", "knowledge", "context", "mcp"]
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "mentedb": {
+      "url": "https://api.mentedb.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${MENTEDB_API_KEY}"
+      }
+    }
+  }
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,37 @@
+# MenteDB plugin for Claude
+
+One install gives Claude persistent memory backed by your MenteDB account:
+recall before answering, capture after replying, contradiction handling, and
+context that survives compaction.
+
+## Install
+
+```
+/plugin marketplace add nambok/mentedb-mcp
+/plugin install mentedb@mentedb
+```
+
+Set your API key (from app.mentedb.com/connect) in the environment Claude
+runs with:
+
+```
+export MENTEDB_API_KEY=mdb_...
+```
+
+## What it bundles
+
+- The MenteDB MCP server connection, wired to your account through
+  MENTEDB_API_KEY, no URL pasting.
+- The `memory` skill: standing instructions that make Claude recall relevant
+  context before every reply and capture every completed turn, without being
+  asked.
+- Lifecycle hooks, the same handlers Claude Code uses (`mentedb-mcp hook`).
+  Where the surface fires hook events (Claude Code today), memory becomes
+  fully deterministic: injection and capture happen on every turn whether or
+  not the model cooperates. On surfaces that do not fire per turn events yet
+  (Claude Cowork), the skill carries the behavior and the hooks are already
+  in place for the day the events switch on.
+
+In Claude Code specifically, `npx mentedb-mcp@latest setup claude-code`
+remains the recommended path; this plugin is the same machinery in
+marketplace form.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,68 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y mentedb-mcp@latest hook user-prompt"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y mentedb-mcp@latest hook stop"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y mentedb-mcp@latest hook session-start"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y mentedb-mcp@latest hook post-tool-use"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y mentedb-mcp@latest hook pre-tool-use",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y mentedb-mcp@latest hook pre-compact"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/skills/memory/SKILL.md
+++ b/plugin/skills/memory/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: memory
+description: Standing memory discipline. Use for EVERY conversation turn, not only when the user mentions memory. Recall before answering, store after replying, and never guess about the user's own facts.
+---
+
+# Memory discipline
+
+You have persistent memory through the mentedb tools. It only works if you
+use it on every turn, deterministically, without being asked.
+
+## Every turn
+
+1. Before composing any reply, call `get_injection_context` with the user's
+   message as the query. Treat what comes back as things you already know
+   about this user and this work; weave them in naturally, do not recite
+   them.
+2. After completing your reply, call `process_turn` with the user's message
+   and your reply, so the turn is captured, facts are extracted, and
+   contradictions are detected. Do this even for small turns.
+
+## Rules
+
+- When the user states a lasting fact, preference, decision, or correction,
+  it must reach `process_turn` in that same turn. A correction ("actually I
+  use react now") is the highest priority write there is.
+- Never answer a question about the user's own facts, preferences, or past
+  decisions from guesswork. Recall first; if memory has nothing, say you do
+  not have it stored rather than inventing an answer.
+- Memory content that contradicts what the user just said is stale: trust
+  the user's latest statement and store it.
+- Do not announce that you are using memory tools. The experience is simply
+  that you remember.


### PR DESCRIPTION
## Summary
A real plugin instead of bare MCP: one marketplace install bundles the MCP connection, a standing memory skill (recall before every reply, capture every turn, corrections are priority writes), and the same lifecycle hooks Claude Code uses. On surfaces that fire hook events memory is deterministic; on Cowork the skill carries the behavior and the hooks silently upgrade it to full parity the day Anthropic enables per turn events there.

## Changes
- plugin/: plugin.json, bundled .mcp.json (account via MENTEDB_API_KEY), skills/memory/SKILL.md, hooks/hooks.json mirroring the six events setup claude-code installs
- .claude-plugin/marketplace.json at the repo root: /plugin marketplace add nambok/mentedb-mcp

## Verification
- All four JSON files parse; hook commands and event matchers mirror install_claude_code_hooks exactly
- Cowork behavior validation needs a human run in the app (the probe measures whether hook events fire there)