### PR TITLE
feat: plugin parity with Claude Code

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,10 +1,19 @@
 {
   "name": "mentedb",
   "description": "Persistent memory for Claude: recalls what matters before answering, stores what it learns after, detects contradictions, and survives compaction. Works in Claude Code today with deterministic lifecycle hooks; in Cowork the bundled memory skill drives recall and capture until per turn hook events are enabled there.",
-  "version": "0.1.0",
-  "author": { "name": "MenteDB", "url": "https://mentedb.com" },
+  "version": "0.2.0",
+  "author": {
+    "name": "MenteDB",
+    "url": "https://mentedb.com"
+  },
   "homepage": "https://mentedb.com/docs",
   "repository": "https://github.com/nambok/mentedb-mcp",
   "license": "Apache-2.0",
-  "keywords": ["memory", "recall", "knowledge", "context", "mcp"]
+  "keywords": [
+    "memory",
+    "recall",
+    "knowledge",
+    "context",
+    "mcp"
+  ]
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -18,20 +18,31 @@ runs with:
 export MENTEDB_API_KEY=mdb_...
 ```
 
+That is the whole setup. The bundled hooks and the MCP connection both
+authenticate from `MENTEDB_API_KEY` directly, no login step.
+
 ## What it bundles
 
 - The MenteDB MCP server connection, wired to your account through
-  MENTEDB_API_KEY, no URL pasting.
+  `MENTEDB_API_KEY`, no URL pasting.
 - The `memory` skill: standing instructions that make Claude recall relevant
   context before every reply and capture every completed turn, without being
-  asked.
+  asked. The skill is surface aware: where lifecycle hooks are active it
+  steps back and lets them run the loop, so nothing is stored twice.
 - Lifecycle hooks, the same handlers Claude Code uses (`mentedb-mcp hook`).
-  Where the surface fires hook events (Claude Code today), memory becomes
-  fully deterministic: injection and capture happen on every turn whether or
-  not the model cooperates. On surfaces that do not fire per turn events yet
-  (Claude Cowork), the skill carries the behavior and the hooks are already
-  in place for the day the events switch on.
+  Where the surface fires hook events, memory is fully deterministic:
+  injection and capture happen on every turn whether or not the model
+  cooperates. Where per turn events are not fired yet, the skill carries the
+  behavior and the hooks are already in place for the day they switch on.
 
-In Claude Code specifically, `npx mentedb-mcp@latest setup claude-code`
-remains the recommended path; this plugin is the same machinery in
-marketplace form.
+## Using it in Claude Code
+
+Pick ONE of the two install paths, not both:
+
+- This plugin, or
+- `npx mentedb-mcp@latest setup claude-code` (the standalone hook setup).
+
+They run the same hook handlers, so either gives the full deterministic
+memory loop. Installing both would register the hooks twice; the handlers
+detect and collapse duplicate fires, so nothing breaks, but there is no
+benefit to a double install.

--- a/plugin/skills/memory/SKILL.md
+++ b/plugin/skills/memory/SKILL.md
@@ -5,10 +5,27 @@ description: Standing memory discipline. Use for EVERY conversation turn, not on
 
 # Memory discipline
 
-You have persistent memory through the mentedb tools. It only works if you
-use it on every turn, deterministically, without being asked.
+You have persistent memory through the mentedb tools. It only works if it
+runs on every turn, deterministically, without being asked.
 
-## Every turn
+## First, know your surface
+
+Lifecycle hooks may already run this loop for you. In Claude Code (and any
+surface that fires per turn hook events), the installed mentedb hooks
+already inject relevant context before each turn and capture the completed
+turn after it. When a `<system-reminder>` or injected context block shows
+memories arriving automatically, hooks are active.
+
+- Hooks active: do NOT call `get_injection_context` or `process_turn`
+  yourself. Doubling the loop stores every turn twice and wastes the plan's
+  turn allowance. Use the tools only for explicit memory work: the user asks
+  what you remember (`list_memories`), asks you to find something
+  (`search_memories`), asks you to forget (`forget_memory`), or hands you an
+  agent file (`ingest_agent_file`).
+- No hooks (Claude Cowork and claude.ai today): run the loop yourself as
+  described below, every turn.
+
+## Every turn (only when hooks are not active)
 
 1. Before composing any reply, call `get_injection_context` with the user's
    message as the query. Treat what comes back as things you already know
@@ -21,11 +38,15 @@ use it on every turn, deterministically, without being asked.
 ## Rules
 
 - When the user states a lasting fact, preference, decision, or correction,
-  it must reach `process_turn` in that same turn. A correction ("actually I
-  use react now") is the highest priority write there is.
+  it must reach memory in that same turn (via `process_turn` when you run
+  the loop, via the Stop hook when hooks are active). A correction
+  ("actually I use react now") is the highest priority write there is.
 - Never answer a question about the user's own facts, preferences, or past
   decisions from guesswork. Recall first; if memory has nothing, say you do
   not have it stored rather than inventing an answer.
+- "What do you remember?" or "do you have memories?" means browse:
+  call `list_memories` (newest first, paginated) and summarize; do not
+  guess a tool name and do not require a search phrase.
 - Memory content that contradicts what the user just said is stale: trust
   the user's latest statement and store it.
 - Do not announce that you are using memory tools. The experience is simply

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -247,9 +247,58 @@ pub async fn run(event: HookEvent, data_dir: PathBuf, force_local: bool) -> anyh
     Ok(())
 }
 
+/// Collapse duplicate hook invocations. A marketplace plugin install and a
+/// settings.json install can both register this same handler; the client then
+/// fires each event twice within milliseconds with identical stdin. Capturing
+/// twice double-stores the turn and double-counts it against the plan, so an
+/// identical (event, payload) pair seen within the window no-ops. The window
+/// is far above the duplicate-registration race and far below any real repeat
+/// of the same event with byte-identical payload. Best effort: any filesystem
+/// failure means "not a duplicate", the hook must never break on this.
+fn is_duplicate_fire(data_dir: &Path, event: &HookEvent, raw: &str) -> bool {
+    use std::hash::{Hash, Hasher};
+
+    const WINDOW: std::time::Duration = std::time::Duration::from_secs(5);
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    raw.hash(&mut hasher);
+    let marker = data_dir
+        .join("hook_dedup")
+        .join(format!("{event:?}-{:016x}", hasher.finish()));
+
+    if let Ok(meta) = std::fs::metadata(&marker)
+        && let Ok(modified) = meta.modified()
+        && modified.elapsed().map(|age| age < WINDOW).unwrap_or(false)
+    {
+        return true;
+    }
+
+    if let Some(dir) = marker.parent() {
+        std::fs::create_dir_all(dir).ok();
+        // Opportunistic prune so the marker dir stays a handful of files.
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let stale = entry
+                    .metadata()
+                    .and_then(|m| m.modified())
+                    .map(|m| m.elapsed().map(|age| age > WINDOW * 12).unwrap_or(true))
+                    .unwrap_or(true);
+                if stale {
+                    std::fs::remove_file(entry.path()).ok();
+                }
+            }
+        }
+    }
+    std::fs::write(&marker, b"").ok();
+    false
+}
+
 async fn run_inner(event: HookEvent, data_dir: &Path, force_local: bool) -> anyhow::Result<()> {
     let mut raw = String::new();
     std::io::stdin().read_to_string(&mut raw).ok();
+    if is_duplicate_fire(data_dir, &event, &raw) {
+        return Ok(());
+    }
     let payload: serde_json::Value = serde_json::from_str(&raw).unwrap_or_else(|_| json!({}));
     let session_id = payload
         .get("session_id")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1005,13 +1005,32 @@ fn mentedb_dir() -> Option<std::path::PathBuf> {
     Some(std::path::PathBuf::from(home_dir()?).join(".mentedb"))
 }
 
-/// Load cloud credentials for the ACTIVE account from ~/.mentedb/cloud.json.
-/// Returns (api_url, token) if a valid active account exists.
+/// Load cloud credentials: MENTEDB_API_KEY env var first, then the ACTIVE
+/// account from ~/.mentedb/cloud.json. Returns (api_url, token).
 ///
-/// The legacy single-key shape is migrated on read (see
+/// The env var must win because plugin installs (the Claude marketplace
+/// plugin) carry the key as environment only and never run `login`; hooks
+/// and the stdio server have to authenticate exactly like the plugin's
+/// bundled .mcp.json server does, or they silently fail open while the MCP
+/// tools work.
+///
+/// The legacy single-key file shape is migrated on read (see
 /// `config::AccountsConfig`), so pre-existing single-key installs keep working.
 /// Also checks the MENTEDB_API_URL env var as an override for the API URL.
 fn load_cloud_credentials() -> Option<(String, String)> {
+    let env_url = || {
+        std::env::var("MENTEDB_API_URL")
+            .ok()
+            .filter(|s| !s.is_empty())
+    };
+
+    if let Ok(key) = std::env::var("MENTEDB_API_KEY")
+        && !key.is_empty()
+    {
+        let api_url = env_url().unwrap_or_else(|| config::DEFAULT_CLOUD_URL.to_string());
+        return Some((api_url, key));
+    }
+
     let dir = mentedb_dir()?;
     let config = config::load_accounts(&dir).ok()?;
     let (_, account) = config.active_account()?;
@@ -1020,8 +1039,7 @@ fn load_cloud_credentials() -> Option<(String, String)> {
     }
 
     // MENTEDB_API_URL env var takes precedence over the account's cloud_url.
-    let api_url = std::env::var("MENTEDB_API_URL")
-        .ok()
+    let api_url = env_url()
         .or_else(|| account.cloud_url.clone())
         .unwrap_or_else(|| config::DEFAULT_CLOUD_URL.to_string());
 


### PR DESCRIPTION
## Summary
- MENTEDB_API_KEY env var now wins in load_cloud_credentials, so plugin installs (key as environment only, no login) authenticate the hooks and the stdio server exactly like the bundled .mcp.json connection; before this the hooks silently failed open while MCP tools worked
- Duplicate hook fire guard: a plugin install plus a settings.json install register the same handlers twice and the client fires each event twice within milliseconds; identical (event, payload) invocations within 5 seconds collapse to one, so turns are never double stored or double counted
- memory skill is surface aware: where hooks are active it uses tools only for explicit memory requests (list, search, forget, ingest), where they are not it runs the per turn loop itself; also routes "what do you remember" to the new list_memories tool
- Plugin README documents the choose one path rule for Claude Code; plugin version 0.2.0

## Verification
- cargo test 59 passed, clippy clean
- Hook auth resolution verified by reading the single choke point (load_cloud_credentials), used by both Backend::resolve and the cloud stdio server